### PR TITLE
ENG-1047: AWS Health notifications in Slack

### DIFF
--- a/aws_health_to_slack/autokitteh.yaml
+++ b/aws_health_to_slack/autokitteh.yaml
@@ -15,6 +15,8 @@ project:
   vars:
     - name: GOOGLE_SHEET_URL
       value: https://docs.google.com/spreadsheets/d/1PalmLwSZOPW9k668_jU-wFI5xCj88a4mDfNUtJAupMQ/
+    - name: TRIGGER_INTERVAL
+      value: 1m
   connections:
     - name: aws_connection
       integration: aws
@@ -25,4 +27,4 @@ project:
   triggers:
     - name: every_minute
       schedule: "@every 1m"
-      call: program.py:on_every_minute
+      call: program.py:on_schedule


### PR DESCRIPTION
Not tested with real data - see https://docs.aws.amazon.com/health/latest/ug/health-api.html

> You must have a Business, Enterprise On-Ramp, or Enterprise Support plan from [AWS Support](https://aws.amazon.com/premiumsupport/) to use the AWS Health API. If you call the AWS Health API from an AWS account that doesn't have a Business, Enterprise On-Ramp, or Enterprise Support plan, you receive a SubscriptionRequiredException error.