### PR TITLE
docs(doc-15): add descriptions to Kittehub project table

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,19 @@ projects for:
 
 | Name                                                          | Description                                                                     | Integrations                      |
 | :------------------------------------------------------------ | :------------------------------------------------------------------------------ | :-------------------------------- |
-| [AWS Health to Slack](./aws_health_to_slack/)                 | Notify about AWS Health events based on resource ownership mapping              | AWS (Health) &rarr; Slack         |
-| [Break-Glass](./break_glass/)                                 | Orchestrate break glass requests and approvals for elevated permissions         | Slack &rarr; AWS (IAM), Jira      |
-| [Categorize Emails](./categorize_emails/)                     | Categorize new emails and notify the appropriate channels based on the content  | Gmail &rarr; ChatGPT &rarr; Slack |
-| [Confluence to Slack](./confluence_to_slack/)                 | Notify when a new page with a specific label is created                         | Confluence &rarr; Slack           |
-| [Create Jira Issue](./create_jira_issue/)                     | Create Jira issues from webhook requests                                        | HTTP &rarr; Jira                  |
-| [Data Pipeline](./data_pipeline/)                             | Process new S3 files: parse and store data in a database pipeline               | AWS (SNS, S3) &rarr; SQLite       |
-| [GitHub Copilot Seats](./github_copilot/)                     | Automate daily GitHub Copilot user pruning and notify users of changes          | GitHub &harr; Slack               |
-| [Google Forms to Jira](./google_forms_to_jira/)               | Poll a form for responses and create an issue for each new entry                | Google Forms &rarr; Jira          |
-| [Jira Assignee From Calendar](./jira_assignee_from_calendar/) | Assign Jira issues based on the current on-call person from a shared calendar   | Jira &harr; Google Calendar       |
-| [Jira to Google Calendar](./jira_to_google_calendar/)         | Create calendar events from Jira issues to schedule and track reviews           | Jira &rarr; Google Calendar       |
-| [Pull Request Review Reminder (Purrr)](./purrr/)              | Streamline code reviews and cut down the turnaround time to merge pull requests | GitHub &harr; Slack               |
-| [ReviewKitteh](./reviewkitteh/)                               | Monitor pull requests, and meow at random people                                | GitHub, Google Sheets, Slack      |
-| [Task Chain](./task_chain/)                                   | Run a sequence of tasks with fault tolerance                                    | Slack                             |
+| 🐍 [AWS Health to Slack](./aws_health_to_slack/)                 | Notify about AWS Health events based on resource ownership mapping              | AWS (Health) &rarr; Slack         |
+| 🐍 [Break-Glass](./break_glass/)                                 | Orchestrate break glass requests and approvals for elevated permissions         | Slack &rarr; AWS (IAM), Jira      |
+| 🐍 [Categorize Emails](./categorize_emails/)                     | Categorize new emails and notify the appropriate channels based on the content  | Gmail &rarr; ChatGPT &rarr; Slack |
+| 🐍 [Confluence to Slack](./confluence_to_slack/)                 | Notify when a new page with a specific label is created                         | Confluence &rarr; Slack           |
+| 🐍 [Create Jira Issue](./create_jira_issue/)                     | Create Jira issues from webhook requests                                        | HTTP &rarr; Jira                  |
+| 🐍 [Data Pipeline](./data_pipeline/)                             | Process new S3 files: parse and store data in a database pipeline               | AWS (SNS, S3) &rarr; SQLite       |
+| ⭐ [GitHub Copilot Seats](./github_copilot/)                     | Automate daily GitHub Copilot user pruning and notify users of changes          | GitHub &harr; Slack               |
+| 🐍 [Google Forms to Jira](./google_forms_to_jira/)               | Poll a form for responses and create an issue for each new entry                | Google Forms &rarr; Jira          |
+| 🐍 [Jira Assignee From Calendar](./jira_assignee_from_calendar/) | Assign Jira issues based on the current on-call person from a shared calendar   | Jira &harr; Google Calendar       |
+| 🐍 [Jira to Google Calendar](./jira_to_google_calendar/)         | Create calendar events from Jira issues to schedule and track reviews           | Jira &rarr; Google Calendar       |
+| ⭐ [Pull Request Review Reminder (Purrr)](./purrr/)              | Streamline code reviews and cut down the turnaround time to merge pull requests | GitHub &harr; Slack               |
+| ⭐ [ReviewKitteh](./reviewkitteh/)                               | Monitor pull requests, and meow at random people                                | GitHub, Google Sheets, Slack      |
+| 🐍 [Task Chain](./task_chain/)                                   | Run a sequence of tasks with fault tolerance                                    | Slack                             |
+
+> [!NOTE]
+> **Legend**: ⭐ Starlark implementation, 🐍 Python implementation

--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ projects for:
 
 | Name                                                          | Description                                                                     | Integrations                      |
 | :------------------------------------------------------------ | :------------------------------------------------------------------------------ | :-------------------------------- |
-| [AWS Health to Slack](./aws_health_to_slack/)                 |                                                                                 | AWS (Health) &rarr; Slack         |
-| [Break-Glass](./break_glass/)                                 |                                                                                 | Slack &rarr; AWS (IAM), Jira      |
-| [Categorize Emails](./categorize_emails/)                     |                                                                                 | Gmail &rarr; ChatGPT &rarr; Slack |
-| [Confluence to Slack](./confluence_to_slack/)                 |                                                                                 | Confluence &rarr; Slack           |
-| [Create Jira Issue](./create_jira_issue/)                     |                                                                                 | HTTP &rarr; Jira                  |
-| [Data Pipeline](./data_pipeline/)                             |                                                                                 | AWS (SNS, S3) &rarr; SQLite       |
-| [GitHub Copilot Seats](./github_copilot/)                     | ... (implemented in Starlark)                                                   | GitHub &harr; Slack               |
-| [Google Forms to Jira](./google_forms_to_jira/)               |                                                                                 | Google Forms &rarr; Jira          |
-| [Jira Assignee From Calendar](./jira_assignee_from_calendar/) |                                                                                 | Jira &harr; Google Calendar       |
-| [Jira to Google Calendar](./jira_to_google_calendar/)         |                                                                                 | Jira &rarr; Google Calendar        |
+| [AWS Health to Slack](./aws_health_to_slack/)                 | Notify about AWS Health events based on resource ownership mapping              | AWS (Health) &rarr; Slack         |
+| [Break-Glass](./break_glass/)                                 | Orchestrate break glass requests and approvals for elevated permissions         | Slack &rarr; AWS (IAM), Jira      |
+| [Categorize Emails](./categorize_emails/)                     | Categorize new emails and notify the appropriate channels based on the content  | Gmail &rarr; ChatGPT &rarr; Slack |
+| [Confluence to Slack](./confluence_to_slack/)                 | Notify when a new page with a specific label is created                         | Confluence &rarr; Slack           |
+| [Create Jira Issue](./create_jira_issue/)                     | Create Jira issues from webhook requests                                        | HTTP &rarr; Jira                  |
+| [Data Pipeline](./data_pipeline/)                             | Process new S3 files: parse and store data in a database pipeline               | AWS (SNS, S3) &rarr; SQLite       |
+| [GitHub Copilot Seats](./github_copilot/)                     | Automate daily GitHub Copilot user pruning and notify users of changes          | GitHub &harr; Slack               |
+| [Google Forms to Jira](./google_forms_to_jira/)               | Poll a form for responses and create an issue for each new entry                | Google Forms &rarr; Jira          |
+| [Jira Assignee From Calendar](./jira_assignee_from_calendar/) | Assign Jira issues based on the current on-call person from a shared calendar   | Jira &harr; Google Calendar       |
+| [Jira to Google Calendar](./jira_to_google_calendar/)         | Create calendar events from Jira issues to schedule and track reviews           | Jira &rarr; Google Calendar       |
 | [Pull Request Review Reminder (Purrr)](./purrr/)              | Streamline code reviews and cut down the turnaround time to merge pull requests | GitHub &harr; Slack               |
 | [ReviewKitteh](./reviewkitteh/)                               | Monitor pull requests, and meow at random people                                | GitHub, Google Sheets, Slack      |
 | [Task Chain](./task_chain/)                                   | Run a sequence of tasks with fault tolerance                                    | Slack                             |


### PR DESCRIPTION
I don’t think adding an additional column for features is necessary.

Here are some thoughts:

from [doc-13](https://linear.app/autokitteh/issue/DOC-13/readmemd-for-kittehub-index-table-showing-what-each-project-does)
>start various connection types, `@autokitteh.activity`, subscribe & next_event, python vs starlark, maybe you can think of a few more.

- **`@autokitteh.activity`:** If we’re trying to minimize the use of `autokitteh.activity`, it doesn’t make sense to highlight it, especially since it's not a concept most users will immediately understand.
- **`subscribe` and `next_event`:** As far as I know, these features aren’t present in Kittehub.
- **Python vs Starlark:** If it's important to distinguish between Python and Starlark implementations, I suggest using an emoji with a legend for clarity. For example:

  ## Legend:
  ⭐️ - Implemented in Starlark  
  🐍 - Implemented in Python
  
...
| 🐍 [Data Pipeline](./data_pipeline/)                          |
| ⭐️ [GitHub Copilot Seats](./github_copilot/)                  |
| 🐍 [Google Forms to Jira](./google_forms_to_jira/)            |
| 🐍 [Jira Assignee From Calendar](./jira_assignee_from_calendar/) |
| 🐍 [Jira to Google Calendar](./jira_to_google_calendar/)      |
| ⭐️ [Pull Request Review Reminder (Purrr)](./purrr/)         |
| ⭐️ [ReviewKitteh](./reviewkitteh/)                           |
| 🐍 [Task Chain](./task_chain/)                                |
