### PR TITLE
chore: remove slack from openai sample

### DIFF
--- a/samples/openai_chatgpt/README.md
+++ b/samples/openai_chatgpt/README.md
@@ -3,9 +3,9 @@
 This [AutoKitteh](https://github.com/autokitteh/autokitteh) project
 demonstrates integration with [ChatGPT](https://chat.openai.com).
 
-The file [`program.star`](./program.star) implements a single entry-point
+The file [`program.py`](./program.py) implements a single entry-point
 function, which is configured in the [`autokitteh.yaml`](./autokitteh.yaml)
-manifest file as the receiver of Slack `slash_command` events.
+manifest file as the receiver of HTTP events.
 
 It sends a couple of requests to the ChatGPT API, and sends the responses
 back to the user over Slack, as well as ChatGPT token usage stats.
@@ -13,16 +13,26 @@ back to the user over Slack, as well as ChatGPT token usage stats.
 API details:
 
 - [OpenAI developer platform](https://platform.openai.com/)
-- [Go client API](https://pkg.go.dev/github.com/sashabaranov/go-openai)
+- [Python client API](https://github.com/openai/openai-python)
 
-This project isn't meant to cover all available functions and events. it
+This project isn't meant to cover all available functions and events. It
 merely showcases a few illustrative, annotated, reusable examples.
 
 ## Instructions
 
-1. Follow instructions [here](https://platform.openai.com/docs/quickstart) to setup your OpenAI API account.
+1. Follow instructions [here](https://platform.openai.com/docs/quickstart) to set up your OpenAI API account.
 
-2. Via the `ak` CLI tool, or the AutoKitteh WebUI, initialize the OpenAI connection and provide API key generated in step 1. 
+2. Via the `ak` CLI tool, or the AutoKitteh WebUI, initialize the OpenAI connection and provide the API key generated in step 1.
 
-3. Via the `ak` CLI tool, or the AutoKitteh VS Code extension, deploy the
-   `autokitteh.yaml` manifest file
+3. Via the `ak` CLI tool, or the AutoKitteh VS Code extension, deploy the `autokitteh.yaml` manifest file.
+
+4. Once deployed, the program is ready to receive HTTP POST requests. You can test the program by sending a POST request to the endpoint as shown below:
+
+   ```shell
+   curl -X POST "http://localhost:9980/webhooks/<webhook_slug>" -H "Content-Type: text/plain" -d "Meow"
+   ```
+
+5. You can modify the request body in the curl command to send custom text and observe how ChatGPT responds with dynamic content.
+
+> [!NOTE]
+> The [`autokitteh.yaml`](autokitteh.yaml) manifest file is set up to filter incoming HTTP requests. You can modify or remove this filter as needed.

--- a/samples/openai_chatgpt/autokitteh.yaml
+++ b/samples/openai_chatgpt/autokitteh.yaml
@@ -12,4 +12,6 @@ project:
   triggers:
     - name: on_http_get
       type: webhook
+      event_type: post
+      filter: data.headers["Content-Type"] == "text/plain"
       call: program.py:on_http_get

--- a/samples/openai_chatgpt/autokitteh.yaml
+++ b/samples/openai_chatgpt/autokitteh.yaml
@@ -9,10 +9,7 @@ project:
   connections:
     - name: chatgpt_conn
       integration: chatgpt
-    - name: slack_conn
-      integration: slack
   triggers:
-    - name: slack_slash_command
-      connection: slack_conn
-      event_type: slash_command
-      call: program.py:on_slack_slash_command
+    - name: on_http_get
+      type: webhook
+      call: program.py:on_http_get

--- a/samples/openai_chatgpt/program.py
+++ b/samples/openai_chatgpt/program.py
@@ -1,40 +1,36 @@
 """This program demonstrates AutoKitteh's OpenAI ChatGPT integration.
 
-This program implements a single entry-point function, which is
-configured in the "autokitteh.yaml" manifest file as the receiver
-of Slack "slash_command" events.
+The program implements a single entry-point function, which is
+configured in the "autokitteh.yaml" manifest file to receive HTTP GET requests.
 
-It sends a couple of requests to the ChatGPT API, and sends the responses
-back to the user over Slack, as well as ChatGPT token usage stats.
+It sends a couple of requests to the ChatGPT API, and returns the responses
+to the user, along with ChatGPT token usage stats.
 
 API details:
 - OpenAI developer platform: https://platform.openai.com/
-- Go client API: https://pkg.go.dev/github.com/sashabaranov/go-openai
+- Python client library: https://github.com/openai/openai-python
 
 This program isn't meant to cover all available functions and events.
 It merely showcases various illustrative, annotated, reusable examples.
-
 """
 
-from autokitteh import openai, slack
+from autokitteh.openai import openai_client
 
 MODEL = "gpt-4o-mini"
 
-chatgpt_client = openai.openai_client("chatgpt_conn")
-slack_client = slack.slack_client("slack_conn")
+chatgpt_client = openai_client("chatgpt_conn")
 
 
-def on_slack_slash_command(event):
-    """https://api.slack.com/interactivity/slash-commands
+def on_http_get(event):
+    """Entry-point function for workflow.
 
-    To use the slash command, simply type `/command-name` in the Slack message input,
-    where `command-name` is the name you have assigned to the command in your app.
-    This command does not require any additional text or arguments.
+    example URL: "http://localhost:9980/webhooks/<webhook_slug>?text=autokittens"
 
     Args:
-        event: Slack event data.
+        event: HTTP event data (including URL query parameters).
     """
-
+    params = event.data.url.query
+    text = params.get("text", "")
     # Example 1: trivial interaction with ChatGPT.
     msg = {"role": "user", "content": "Meow!"}
     resp = chatgpt_client.chat.completions.create(model=MODEL, messages=[msg])
@@ -51,13 +47,11 @@ def on_slack_slash_command(event):
     ]
     msgs = [
         {"role": "system", "content": contents[0]},
-        {"role": "user", "content": contents[1]},
-        {"role": "user", "content": event.data["text"]},
+        {"role": "user", "content": text if text else contents[1]},
     ]
 
     resp = chatgpt_client.chat.completions.create(model=MODEL, messages=msgs)
 
-    id = event.data["user_id"]
     for choice in resp.choices:
-        slack_client.chat_postMessage(channel=id, text=choice.message.content)
-    slack_client.chat_postMessage(channel=id, text=f"Usage: `{str(resp.usage)}`")
+        print(choice.message.content)
+    print(f"Usage: `{str(resp.usage)}`")

--- a/samples/openai_chatgpt/program.py
+++ b/samples/openai_chatgpt/program.py
@@ -27,7 +27,7 @@ def on_http_get(event):
 
     Example usage:
     - URL: "http://localhost:9980/webhooks/<webhook_slug>"
-    - Curl command: 
+    - Curl command:
       curl -X POST "<URL>" -H "Content-Type: text/plain" -d "Meow"
 
     Args:

--- a/samples/openai_chatgpt/program.py
+++ b/samples/openai_chatgpt/program.py
@@ -3,8 +3,8 @@
 The program implements a single entry-point function, which is
 configured in the "autokitteh.yaml" manifest file to receive HTTP GET requests.
 
-It sends a couple of requests to the ChatGPT API, and returns the responses
-to the user, along with ChatGPT token usage stats.
+It sends a couple of requests to the ChatGPT API, and prints the responses
+in the AutoKitteh session log, along with ChatGPT token usage stats.
 
 API details:
 - OpenAI developer platform: https://platform.openai.com/
@@ -22,15 +22,19 @@ chatgpt_client = openai_client("chatgpt_conn")
 
 
 def on_http_get(event):
-    """Entry-point function for workflow.
+    """
+    Entry-point function for handling HTTP GET requests in this workflow.
 
-    example URL: "http://localhost:9980/webhooks/<webhook_slug>?text=autokittens"
+    Example usage:
+    - URL: "http://localhost:9980/webhooks/<webhook_slug>"
+    - Curl command: 
+      curl -X POST "<URL>" -H "Content-Type: text/plain" -d "Meow"
 
     Args:
-        event: HTTP event data (including URL query parameters).
+        event: The HTTP event containing request data.
     """
-    params = event.data.url.query
-    text = params.get("text", "")
+    body = event.data.body.bytes.decode("utf-8")
+    print(body)
     # Example 1: trivial interaction with ChatGPT.
     msg = {"role": "user", "content": "Meow!"}
     resp = chatgpt_client.chat.completions.create(model=MODEL, messages=[msg])
@@ -47,11 +51,11 @@ def on_http_get(event):
     ]
     msgs = [
         {"role": "system", "content": contents[0]},
-        {"role": "user", "content": text if text else contents[1]},
+        {"role": "user", "content": body if body else contents[1]},
     ]
 
     resp = chatgpt_client.chat.completions.create(model=MODEL, messages=msgs)
 
     for choice in resp.choices:
         print(choice.message.content)
-    print(f"Usage: `{str(resp.usage)}`")
+    print(f"Usage: `{resp.usage}`")

--- a/samples/openai_chatgpt/program.py
+++ b/samples/openai_chatgpt/program.py
@@ -35,6 +35,7 @@ def on_http_get(event):
     """
     body = event.data.body.bytes.decode("utf-8")
     print(body)
+
     # Example 1: trivial interaction with ChatGPT.
     msg = {"role": "user", "content": "Meow!"}
     resp = chatgpt_client.chat.completions.create(model=MODEL, messages=[msg])

--- a/samples/openai_chatgpt/program.py
+++ b/samples/openai_chatgpt/program.py
@@ -51,7 +51,7 @@ def on_http_get(event):
     ]
     msgs = [
         {"role": "system", "content": contents[0]},
-        {"role": "user", "content": body if body else contents[1]},
+        {"role": "user", "content": body or contents[1]},
     ]
 
     resp = chatgpt_client.chat.completions.create(model=MODEL, messages=msgs)


### PR DESCRIPTION
The sample uses a URL parameter for input, which simplifies the implementation but might not be realistic for more complex prompts. I have two options for addressing this:

- **Option 1**: Document the current approach, informing users of its limitations with URL parameters for input.
- **Option 2**: Rewrite the sample to accept input through the request body, which would introduce slightly more complexity but offer greater flexibility.

Additionally, I’ve adjusted how user input influences the prompt. Previously, with the URL parameter approach, the input wasn’t impacting ChatGPT’s responses as expected. Now, users can directly enter their own prompt and see its effect on the output more clearly. If we switch to using a JSON body, we might be able to revert to the previous method of prompting ChatGPT, as longer inputs could have a more noticeable impact.