### PR TITLE
feat: add jira ticketing handling workflow

### DIFF
--- a/jira_ticket_handling/README.md
+++ b/jira_ticket_handling/README.md
@@ -1,0 +1,89 @@
+
+# Jira-Slack Issue Workflow Automation
+
+This project automates the process of creating Slack channels for new Jira issues and streamlines issue management. It listens for new Jira issues, creates a dedicated Slack channel for each issue, invites the issue creator to the channel, and waits for the user to confirm completion by mentioning the Slack app with `@ak done`. Once confirmed, it archives the channel, notifies the channel members, and updates the Jira issue status to `DONE`.
+
+> [!IMPORTANT]
+> The command `@ak done` assumes that you have named your custom Slack app "ak." If you used a different name, be sure to substitute "ak" with the appropriate name of your Slack app when mentioning it in a Slack channel.
+
+## How It Works
+
+- **Detect New Jira Issues:** The program listens for new issues created in Jira.
+- **Create Slack Channel:** When a new issue is detected, it creates a Slack channel named after the issue key and summary.
+- **Invite Issue Creator:** Invites the issue creator to the Slack channel.
+- **Await User Confirmation:** Waits for the user to confirm completion by typing `@ak done` in the Slack channel.
+- **Archive Channel and Update Jira:** Notifies channel members, archives the Slack channel, and updates the Jira issue status to `DONE`.
+
+## Installation and Usage
+
+- [Install AutoKitteh](https://docs.autokitteh.com/get_started/install)
+
+### Configure Integrations
+
+- [Jira Integration](https://docs.autokitteh.com/integrations/atlassian/config)
+- [Slack Integration](https://docs.autokitteh.com/integrations/slack/config)
+
+### Clone the Repository
+
+```shell
+git clone https://github.com/autokitteh/kittehub.git
+cd kittehub/jira_ticket_handling
+```
+
+Alternatively, you can copy the individual files in this directory.
+
+### Run the AutoKitteh Server
+
+Simply run this command:
+
+```shell
+ak up --mode dev
+```
+
+### Apply Manifest and Deploy Project
+
+1. Navigate to the `jira_slack_issue_workflow` directory:
+
+   ```shell
+   cd jira_slack_issue_workflow
+   ```
+
+2. Apply the manifest and deploy the project by running the following command:
+
+   ```shell
+   ak deploy --manifest autokitteh.yaml
+   ```
+
+   The output of this command will be important for initializing connections in the following step if you're using the CLI.
+
+   For example, for each configured connection, you will see a line that looks similar to the one below:
+
+   ```shell
+   [exec] create_connection "jira_slack_issue_workflow/slack_conn": con_01j36p9gj6e2nt87p9vap6rbmz created
+   ```
+
+   `con_01j36p9gj6e2nt87p9vap6rbmz` is the connection ID.
+
+### Initialize Connections
+
+> [!IMPORTANT]
+> `slack_conn` and `jira_conn` need to be initialized using the IDs from the previous step.
+
+Using the connection IDs from the previous step, run these commands:
+
+```shell
+ak connection init jira_conn <connection ID>
+ak connection init slack_conn <connection ID>
+```
+
+### Trigger the Workflow
+
+The workflow is triggered when a new issue is created in Jira.
+
+## Customization
+
+Feel free to customize the workflow to suit your needs. For example, you can:
+
+- Change the trigger event or conditions.
+- Modify the message content or notification methods.
+- Integrate additional services or automate more steps.

--- a/jira_ticket_handling/README.md
+++ b/jira_ticket_handling/README.md
@@ -66,14 +66,18 @@ ak up --mode dev
 ### Initialize Connections
 
 > [!IMPORTANT]
-> `slack_conn` and `jira_conn` need to be initialized using the IDs from the previous step.
+> `slack_conn` and `jira_conn_api_key` need to be initialized using the IDs from the previous step.
 
 Using the connection IDs from the previous step, run these commands:
 
 ```shell
-ak connection init jira_conn <connection ID>
+ak connection init jira_conn_api_key <connection ID>
+ak connection init jira_events_oauth <connection ID>
 ak connection init slack_conn <connection ID>
 ```
+> [!WARNING]
+> The `jira_conn_api_key` connection is used to send requests to the Jira API and needs to be initialized with an API key.
+> The `jira_events_oauth` connection is used to listen for events from Jira. It must be initialized with the OAuth connection ID.
 
 ### Trigger the Workflow
 

--- a/jira_ticket_handling/README.md
+++ b/jira_ticket_handling/README.md
@@ -2,15 +2,15 @@
 
 This project automates the process of creating Slack channels for new Jira issues and streamlines issue management. It listens for new Jira issues, creates a dedicated Slack channel for each issue, invites the issue creator to the channel, and waits for the user to confirm completion by mentioning the Slack app with `@ak done`. Once confirmed, it archives the channel, notifies the channel members, and updates the Jira issue status to `DONE`.
 
-> [!IMPORTANT]
-> The command `@ak done` assumes that you have named your custom Slack app "ak." If you used a different name, be sure to substitute "ak" with the appropriate name of your Slack app when mentioning it in a Slack channel.
+> [!IMPORTANT]  
+> The mention `@autokitteh done` assumes that you have named your custom Slack app "autokitteh." If you used a different name, be sure to substitute "autokitteh" with the appropriate name of your Slack app when mentioning it in a Slack channel.
 
 ## How It Works
 
 - **Detect New Jira Issues:** The program listens for new issues created in Jira.
 - **Create Slack Channel:** When a new issue is detected, it creates a Slack channel named after the issue key and summary.
 - **Invite Issue Creator:** Invites the issue creator to the Slack channel.
-- **Await User Confirmation:** Waits for the user to confirm completion by typing `@ak done` in the Slack channel.
+- **Await User Confirmation:** Waits for the user to confirm completion by typing `@autokitteh done` in the Slack channel.
 - **Archive Channel and Update Jira:** Notifies channel members, archives the Slack channel, and updates the Jira issue status to `DONE`.
 
 ## Installation and Usage

--- a/jira_ticket_handling/README.md
+++ b/jira_ticket_handling/README.md
@@ -1,4 +1,3 @@
-
 # Jira-Slack Issue Workflow Automation
 
 This project automates the process of creating Slack channels for new Jira issues and streamlines issue management. It listens for new Jira issues, creates a dedicated Slack channel for each issue, invites the issue creator to the channel, and waits for the user to confirm completion by mentioning the Slack app with `@ak done`. Once confirmed, it archives the channel, notifies the channel members, and updates the Jira issue status to `DONE`.

--- a/jira_ticket_handling/autokitteh.yaml
+++ b/jira_ticket_handling/autokitteh.yaml
@@ -1,0 +1,18 @@
+# This YAML file is a declarative manifest that describes the setup of an
+# AutoKitteh project that implements a Jira ticket handling system.
+
+version: v1
+
+project:
+  name: jira_ticket_handling
+  connections:
+    - name: jira_conn
+      integration: jira
+    - name: slack_conn
+      integration: slack
+  triggers:
+    - name: jira_issue_created
+      connection: jira_conn
+      event_type: issue_created
+      filter: data.issue.fields.project.key == "PK"
+      call: program.py:on_jira_issue_created

--- a/jira_ticket_handling/autokitteh.yaml
+++ b/jira_ticket_handling/autokitteh.yaml
@@ -6,13 +6,15 @@ version: v1
 project:
   name: jira_ticket_handling
   connections:
-    - name: jira_conn
+    - name: jira_conn_api_key
+      integration: jira
+    - name: jira_events_oauth
       integration: jira
     - name: slack_conn
       integration: slack
   triggers:
     - name: jira_issue_created
-      connection: jira_conn
+      connection: jira_events_oauth
       event_type: issue_created
-      filter: data.issue.fields.project.key == "PK"
+      filter: data.issue.fields.project.key == "<project_key>"
       call: program.py:on_jira_issue_created

--- a/jira_ticket_handling/program.py
+++ b/jira_ticket_handling/program.py
@@ -1,0 +1,79 @@
+"""This program listens for new Jira issues and creates a Slack channel for each issue.
+It then invites the issue creator to the channel and waits for the user to confirm completion by mentioning the Slack app with @app 'done'.
+Once confirmed, it archives the channel, notifies the channel members, and updates the Jira issue status to 'DONE'.
+"""
+
+import re
+
+import autokitteh
+from autokitteh.atlassian import jira_client
+from autokitteh.slack import slack_client
+
+slack = slack_client("slack_conn")
+jira = jira_client("jira_conn")
+
+
+def on_jira_issue_created(event):
+    """Entry point for workflow"""
+    issue_key = event.data.issue.key
+    channel_id = create_slack_channel(event.data.issue, issue_key)
+
+    # Invite the issue creator to the channel
+    creator_id = event.data.issue.fields.creator.accountId
+    user_id = fetch_slack_user_id_by_jira_account(creator_id)
+    slack.conversations_invite(channel=channel_id, users=[user_id])
+
+    wait_for_user_confirmation(channel_id)
+
+    # Archive the channel and notify the channel members
+    notify_channel_members(issue_key, channel_id)
+    slack.conversations_archive(channel=channel_id)
+    print(f"Channel {channel_id} archived successfully.")
+
+    jira.set_issue_status(issue_key, "DONE")
+
+
+def wait_for_user_confirmation(channel_id):
+    """Wait for the user to confirm completion by typing 'done' in the Slack channel."""
+    event_filter = "event_type == 'app_mention'"
+    sub = autokitteh.subscribe("slack_conn", event_filter)
+    while True:
+        mention = autokitteh.next_event(sub)
+        if mention.channel != channel_id:
+            continue
+        if "done" in mention.text.lower():
+            break
+    autokitteh.unsubscribe(sub)
+
+
+def notify_channel_members(issue_key, channel_id):
+    result = slack.conversations_members(channel=channel_id)
+    members = result["members"]
+    for member_id in members:
+        msg = f"Hey <@{member_id}>, the Jira ticket {issue_key} is closed. The channel will be archived shortly."
+        slack.chat_postMessage(channel=member_id, text=msg)
+
+
+def create_slack_channel(issue, issue_key):
+    """Create a Slack channel for the given Jira issue."""
+    channel_name = f"issue-key-{issue_key}_{issue.fields.summary}"
+    channel_name = sanitize_channel_name(channel_name)
+    response = slack.conversations_create(name=channel_name, is_private=False)
+    channel_id = response["channel"]["id"]
+    print(f"Channel created successfully with ID: {channel_id}")
+    return channel_id
+
+
+def fetch_slack_user_id_by_jira_account(account_id):
+    """Fetch the Slack user ID associated with a given Jira account ID."""
+    jira_user = jira.user(account_id=account_id)
+    email = jira_user.get("emailAddress")
+    response = slack.users_lookupByEmail(email=email)
+    user_id = response["user"]["id"]
+    return user_id
+
+
+def sanitize_channel_name(name):
+    """Sanitize the channel name to be Slack-compatible."""
+    sanitized_name = re.sub(r"[^a-z0-9_\-]", "-", name.lower())
+    return sanitized_name

--- a/jira_ticket_handling/program.py
+++ b/jira_ticket_handling/program.py
@@ -1,5 +1,5 @@
 """This program listens for new Jira issues and creates a Slack channel for each issue.
-It then invites the issue creator to the channel and waits for the user to confirm completion by mentioning the Slack app with @app 'done'.
+It then invites the issue creator to the channel and waits for the user to confirm completion by mentioning the Slack app with @ak 'done'.
 Once confirmed, it archives the channel, notifies the channel members, and updates the Jira issue status to 'DONE'.
 """
 

--- a/jira_ticket_handling/program.py
+++ b/jira_ticket_handling/program.py
@@ -9,6 +9,7 @@ import autokitteh
 from autokitteh.atlassian import jira_client
 from autokitteh.slack import slack_client
 
+
 slack = slack_client("slack_conn")
 jira = jira_client("jira_conn")
 


### PR DESCRIPTION
**Known Limitations:**

- **Slack Invitations:** Due to a Jira permissions issue that requires further investigation, only the creator of the issue is automatically invited to the Slack channel. All other participants must be added manually.
- **Channel Filtering:** Adding a channel filter alongside the mention filter—specifically using `'app_mention' && data.event.channel == 'C07QKNEF610'`—did not work. As a workaround, the event is checked within the Python code.  
  ^ The issue is we haven't decided on syntax which is being tracked [here](https://linear.app/autokitteh/issue/ENG-1654/bug-unable-to-add-filter-for-a-slack-event-using-subscribenext-event).  
  I'm open to changing it to the current filter syntax, but that means it would potentially break once that change merges.