### PR TITLE
chore: fix and update event handling sample

### DIFF
--- a/samples/runtime_events/README.md
+++ b/samples/runtime_events/README.md
@@ -4,9 +4,12 @@
 path that ends with `/meow`. The trigger is defined in the
 [autokitteh.yaml](./autokitteh.yaml) manifest file.
 
-During runtime, it waits (up to 60 seconds) for a subsequent webhook event
+During runtime, it waits (up to 1 minute) for a subsequent webhook event
 where the URL path ends with `/woof`, using the `subscribe` and `get_event`
-AutoKitteh Python SDK functions.
+functiona in the AutoKitteh Python SDK.
+
+For detailed information about runtime event subscriptions, see:
+https://docs.autokitteh.com/develop/events/subscription
 
 ## Setup Instructions
 

--- a/samples/runtime_events/autokitteh.yaml
+++ b/samples/runtime_events/autokitteh.yaml
@@ -9,5 +9,5 @@ project:
     - name: meow_webhook
       type: webhook
       event_type: get
-      filter: data.url.path.endsWith("/meow")
+      filter: data.url.path.endsWith('/meow')
       call: program.py:on_http_get_meow

--- a/samples/runtime_events/program.py
+++ b/samples/runtime_events/program.py
@@ -1,5 +1,7 @@
 """This program demonstrates AutoKitteh's runtime event handling."""
 
+from datetime import timedelta
+
 import autokitteh
 
 
@@ -7,13 +9,14 @@ def on_http_get_meow(event):
     """This workflow is triggered by a predefined HTTP GET request event."""
     print("Got a meow, waiting for a woof")
 
-    # Wait (up to 60 seconds) for a subsequent webhook
+    # Wait (up to 1 minute) for a subsequent webhook
     # event where the URL path ends with "woof".
     filter = "data.url.path.endsWith('/woof')"
     sub = autokitteh.subscribe("meow_webhook", filter)
-    next = autokitteh.next_event(sub, timeout=60)
+    delta = timedelta(minutes=1)
+    next = autokitteh.next_event(sub, timeout=delta)
 
     if next:
-        print("Got a woof: ", next)
+        print("Got a woof:", next)
     else:
         print("Timeout!")


### PR DESCRIPTION
Fix existing sample to use `timedelta` instead of `int` for the `timeout` parameter.

Also, reference new documentation (https://github.com/autokitteh/docs.autokitteh.com/pull/124).