### PR TITLE
chore(room_reservation): change workflow trigger from command to text

### DIFF
--- a/room_reservation/README.md
+++ b/room_reservation/README.md
@@ -9,11 +9,17 @@ While users can reserve rooms directly from the calendar, we wanted to add a
 Slack interface to make it even quicker to reserve a room for an immediate
 meeting within the next half hour.
 
-We configured three slash commands in Slack:
+We did not configure separate slash commands in Slack. Instead, we listen for the `/autokitteh`
+command and parse the text that follows to determine the desired action. 
+The format of the commands is as follows:
 
-- `/availablerooms` - list all the available rooms
-- `/roomstatus <room>` - check the status of a specific room
-- `/reserveroom <room> <title>` - reserve a specific room
+- `/autokitteh availablerooms` - list all the available rooms
+- `/autokitteh roomstatus <room>` - check the status of a specific room
+- `/autokitteh reserveroom <room> <title>` - reserve a specific room
+
+> [!IMPORTANT]
+> If you're using Socket Mode or the open source version, replace `/autokitteh` 
+with your app's name (e.g., `/yourapp availablerooms`).
 
 > [!TIP]
 > You can extend this project to add participants, set the time, etc.

--- a/room_reservation/autokitteh.yaml
+++ b/room_reservation/autokitteh.yaml
@@ -14,7 +14,7 @@ project:
   name: room_reservation
   vars:
     - name: GOOGLE_SHEET_ID
-      value: ""
+      value:
   connections:
     - name: calendar_conn
       integration: googlecalendar
@@ -26,15 +26,15 @@ project:
     - name: slack_slash_command_available_rooms
       connection: slack_conn
       event_type: slash_command
-      filter: data.command == "/availablerooms"
+      filter: data.text == "availablerooms"
       call: available_rooms.py:on_slack_slash_command
     - name: slack_slash_command_room_status
       connection: slack_conn
       event_type: slash_command
-      filter: data.command == "/roomstatus"
+      filter: data.text.startsWith("roomstatus ")
       call: room_status.py:on_slack_slash_command
     - name: slack_slash_command_reserve_room
       connection: slack_conn
       event_type: slash_command
-      filter: data.command == "/reserveroom"
+      filter: data.text.startsWith("reserveroom ")
       call: reserve_room.py:on_slack_slash_command

--- a/room_reservation/available_rooms.py
+++ b/room_reservation/available_rooms.py
@@ -6,11 +6,11 @@ from autokitteh.google import google_calendar_client
 from autokitteh.slack import slack_client
 from googleapiclient.errors import HttpError
 
-import google_sheets
+from util import get_room_list
 
 
 def on_slack_slash_command(event):
-    """Entry point for the "/availablerooms" Slack slash command."""
+    """Entry point for the "/<app-name> availablerooms" Slack slash command."""
     slack = slack_client("slack_conn")
     channel_id = event.data.user_id  # event.data.channel_id
 
@@ -21,7 +21,7 @@ def on_slack_slash_command(event):
     # Iterate over the list of rooms, notify the user about
     # each room which is available in the next half hour.
     available = False
-    for room in sorted(google_sheets.get_room_list()):
+    for room in sorted(get_room_list()):
         print(f"Checking upcoming events in: {room}")
         try:
             events = gcal.list(

--- a/room_reservation/reserve_room.py
+++ b/room_reservation/reserve_room.py
@@ -7,22 +7,25 @@ from autokitteh.google import google_calendar_client
 from autokitteh.slack import slack_client
 from googleapiclient.errors import HttpError
 
-import google_sheets
+from util import get_room_list, get_email_from_slack_command
 
 
 def on_slack_slash_command(event):
-    """Entry point for the "/reserveroom <room> <title>" Slack slash command."""
+    """Entry point for the "/<app-name> reserveroom <room> <title>" Slack slash command."""
     slack = slack_client("slack_conn")
     channel_id = event.data.user_id  # event.data.channel_id
 
-    cmd_text = event.data.text.split(maxsplit=1)
-    if len(cmd_text) < 2:
-        err = "Error: please use the following format: `/reserveroom <room> <title>`"
+    cmd_text = event.data.text.split(maxsplit=2)
+
+    if len(cmd_text) < 3:
+        err = "Error: please use the following format: `/<app-name> reserveroom <room> <title>`"
         slack.chat_postMessage(channel=channel_id, text=err)
         return
+    _, room, title = cmd_text
 
-    room, title = cmd_text
-    if room not in google_sheets.get_room_list():
+    room = get_email_from_slack_command(room)
+
+    if room not in get_room_list():
         err = f"Error: `{room}` not found in the list of rooms"
         slack.chat_postMessage(channel=channel_id, text=err)
         return

--- a/room_reservation/room_status.py
+++ b/room_reservation/room_status.py
@@ -7,16 +7,19 @@ from autokitteh.google import google_calendar_client
 from autokitteh.slack import slack_client
 from googleapiclient.errors import HttpError
 
-import google_sheets
+from util import get_email_from_slack_command, get_room_list
 
 
 def on_slack_slash_command(event):
-    """Entry point for the "/roomstatus <room>" Slack slash command."""
+    """Entry point for the "/<app-name> roomstatus <room>" Slack slash command."""
     slack = slack_client("slack_conn")
     channel_id = event.data.user_id  # event.data.channel_id
 
-    room = event.data.text
-    if room not in google_sheets.get_room_list():
+    # Extract the email address from the Slack command text, which is formatted like:
+    # "<@USER_ID> <mailto:test@example.com|test@example.com>".
+    room = get_email_from_slack_command(event.data.text)
+
+    if room not in get_room_list():
         err = f"Error: `{room}` not found in the list of rooms"
         slack.chat_postMessage(channel=channel_id, text=err)
 

--- a/room_reservation/util.py
+++ b/room_reservation/util.py
@@ -7,3 +7,9 @@ def get_room_list():
     sheet = google_sheets_client("sheets_conn").spreadsheets().values()
     rows = sheet.get(spreadsheetId=os.getenv("GOOGLE_SHEET_ID"), range="A:A").execute()
     return [cell[0] for cell in rows.get("values", []) if cell]
+
+
+def get_email_from_slack_command(text):
+    """Extract the email address from the Slack command text, which is formatted like:
+    "<@USER_ID> <mailto:test@example.com|test@example.com>"."""
+    return text.split("|")[-1].strip(">")


### PR DESCRIPTION
By switching to data.text, we avoid the need to register specific commands, allowing users the flexibility to modify or add their own commands. While this approach doesn’t offer all the benefits of a traditional slash command, it provides greater adaptability. To handle this, a utility function was added to parse the text, as the email format returned by Slack was not directly usable. 

Additionally, the README and docstrings were updated to reflect these changes.