### PR TITLE
fix: use `get_base_url` in order to make sure `base_url` is set

### DIFF
--- a/break_glass/program.py
+++ b/break_glass/program.py
@@ -25,7 +25,7 @@ import os
 from pathlib import Path
 
 import autokitteh
-from autokitteh.atlassian import jira_client
+from autokitteh.atlassian import jira_client, get_base_url
 from autokitteh.slack import slack_client
 from requests.exceptions import HTTPError
 
@@ -98,7 +98,7 @@ def parse_event_data(event):
     form_data = event.data["view"]["state"]["values"]
     reason = form_data["block_reason"]["reason"]["value"]
     issue_key = form_data["block_issue_key"]["issue_key"]["value"]
-    base_url = os.getenv("jira_connection__AccessURL")
+    base_url = get_base_url("jira_connection")
     requester_id = event.data["user"]["id"]
     return reason, issue_key, base_url, requester_id
 


### PR DESCRIPTION
When authenticating with PAT or API Key, `base_url` was `None` because only OAuth has `__AccessURL`