### PR TITLE
fix(samples): activate `start_github_action` and update `repo` to `repository` per eng-1631

### DIFF
--- a/samples/github/autokitteh.yaml
+++ b/samples/github/autokitteh.yaml
@@ -29,8 +29,7 @@ project:
       connection: github_conn
       event_type: workflow_run
       call: workflow.py:on_github_workflow_run
-    # Uncomment the following trigger:
-    # - name: github_push
-    #   connection: github_conn
-    #   event_type: push
-    #   call: workflow.py:start_github_action
+    - name: github_push
+      connection: github_conn
+      event_type: push
+      call: workflow.py:start_github_action

--- a/samples/github/workflow.py
+++ b/samples/github/workflow.py
@@ -6,21 +6,11 @@ from autokitteh.github import github_client
 def start_github_action(event):
     """Start a GitHub action workflow.
 
-    See the following link for more information:
-    https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+    This function is preconfigured as the entry point for an AutoKitteh trigger.
+    It will function correctly once a named workflow YAML file is created in a
+    relevant GitHub repository under the ".github/workflows" directory.
 
-    This function is preconfigured as the entry-point for an AutoKitteh trigger,
-    but it's currently commented out in the "autokitteh.yaml" file. To activate it,
-    uncomment the following lines:
-
-        # - name: github_push
-        #   connection: github_conn
-        #   event_type: push
-        #   call: workflow.py:start_github_action
-
-    Additionally, it requires a named workflow YAML file to be present in a relevant GitHub repository.
-
-    Example workflow YAML file (in the repo's ".github/workflows" directory):
+    Example workflow YAML file:
 
         on: workflow_dispatch
         jobs:
@@ -29,12 +19,15 @@ def start_github_action(event):
             steps:
               - run: echo "Do stuff"
 
+    To fully utilize this trigger, ensure the workflow file is named appropriately
+    (e.g., "dispatch.yml") and is configured for the intended events.
+
     Args:
-        event: GitHub event data (e.g. new pull request or push event).
+        event: GitHub event data (e.g., a new pull request or push event).
     """
-    repo = event.data.repo.full_name
+    repo = event.data.repository.full_name
     # TODO: ENG-1631
-    ref = event.data.repo.default_branch  # Branch name or tag
+    ref = event.data.repository.default_branch  # Branch name or tag
     workflow_file = "dispatch.yml"  # .github/workflows/dispatch.yml
 
     g = github_client("github_conn")


### PR DESCRIPTION
**Issues Addressed:**
- The `start_github_action` trigger function was previously commented out to encourage users to configure the workflow file before running the sample. This was relevant before cloud, where the `.yaml` file was easily accessible, which is no longer the case. The solution is to keep the trigger function active from the start. I updated the docstring to include clear instructions reflecting this change.
- The push event was not received from the app because push events were not activated in the app configuration.
- Per ENG-1631, I updated instances of `repo` to `repository` to align with how GitHub structures JSON event data.