### PR TITLE
ENG-1848: Deleting unnecessary filters from webhooks in GitHub_actions sample

### DIFF
--- a/github_actions/README.md
+++ b/github_actions/README.md
@@ -60,28 +60,28 @@ triggering actions in specific repositories based on the completion of workflows
    (use the **1st** URL path from step 4 above):
 
    ```shell
-   curl -i "http://localhost:9980/webhooks/<webhook-slug>/cross-repo"
+   curl -i "http://localhost:9980/webhooks/<webhook-slug>"
    ```
 
 2. Run this command to initiate the Fan-out trigger 
-   (use the **2nd** URL path from step 3 above):
+   (use the **2nd** URL path from step 4 above):
 
    ```shell
-   curl -i "http://localhost:9980/webhooks/<webhook-slug>/fan-out"
+   curl -i "http://localhost:9980/webhooks/<webhook-slug>"
    ```
 
 3. Run this command for the OR trigger 
-   (use the **3rd** URL path from step 3 above):
+   (use the **3rd** URL path from step 4 above):
 
    ```shell
-   curl -i "http://localhost:9980/webhooks/<webhook-slug>/or-trigger"
+   curl -i "http://localhost:9980/webhooks/<webhook-slug>"
    ```
 
 4. Run this command for the Fan-in trigger 
-   (use the **4th** URL path from step 3 above):
+   (use the **4th** URL path from step 4 above):
 
    ```shell
-   curl -i "http://localhost:9980/webhooks/<webhook-slug>/fan-in"
+   curl -i "http://localhost:9980/webhooks/<webhook-slug>"
    ```
 
 5. Check out the resulting session logs in the AutoKitteh server for each of 

--- a/github_actions/autokitteh.yaml
+++ b/github_actions/autokitteh.yaml
@@ -26,20 +26,16 @@ project:
     - name: cross_repo
       type: webhook
       event_type: get
-      filter: data.url.path.endsWith("/cross-repo")
       call: program.py:on_cross_repo
     - name: fan_out
       type: webhook
       event_type: get
-      filter: data.url.path.endsWith("/fan-out")
       call: program.py:on_fan_out
     - name: or_trigger
       type: webhook
       event_type: get
-      filter: data.url.path.endsWith("/or-trigger")
       call: program.py:on_or_trigger
     - name: on_fan_in
       type: webhook
       event_type: get
-      filter: data.url.path.endsWith("/fan-in")
       call: program.py:on_fan_in


### PR DESCRIPTION
ENG-1848. To enhance clarity for users and address a similar issue I encountered, we decided to remove the webhook filters, as each function now has its own dedicated webhook. I have updated the manifest file to remove the filters and revised the README accordingly to reflect these changes.