### PR TITLE
feat: add hackernews project in kittehub

### DIFF
--- a/hackernews/README.md
+++ b/hackernews/README.md
@@ -24,7 +24,7 @@ This project monitors Hacker News for new articles matching a specific topic, fe
 ## Trigger Workflow
 
 - Type `/your-slack-app topic` in the Slack channel you set in the environment variable, replacing `topic` with what you want to search for, to start tracking articles
-- The workflow runs automatically every two minutes after deployment. 
+- The workflow runs automatically every two minutes after deployment
 
 #### Prerequisites
 - [Install AutoKitteh](https://docs.autokitteh.com/get_started/install)

--- a/hackernews/README.md
+++ b/hackernews/README.md
@@ -1,0 +1,27 @@
+---
+title: Hackernews Alert with Slack 
+description: A bot that tracks Hacker News articles by topic and sends updates to Slack.
+integrations: ["slack"]
+categories: ["Office Automation"]
+---
+
+
+# Hackernews Slack Sample
+
+This project monitors Hacker News for new articles matching a specific topic, fetching their details in real-time. It compares the latest results with previously fetched articles to identify new ones and sends their title and URL as notifications to a Slack channel.
+
+## API Documentation
+
+- Slack connection. https://docs.autokitteh.com/integrations/slack.
+- Fetches articles from Hacker News. https://www.algolia.com/doc/api-reference/rest-api.
+
+## Setup Instructions
+
+1. Set the `SLACK_CHANNEL` environment value
+
+2. Via the ak CLI tool or the AutoKitteh VS Code extension, deploy the autokitteh.yaml manifest file, or you can use the cloud version for easy deployment and management.
+
+## Usage Instruction 
+
+- Type `/your_slack_app` `topic` in the Slack channel you set in the environment variable, replacing `topic` with what you want to search for, to start tracking articles.
+

--- a/hackernews/README.md
+++ b/hackernews/README.md
@@ -11,9 +11,9 @@ This project monitors Hacker News for new articles matching a specific topic, fe
 
 ## How It Works
 
-1. Read the topic from the Slack command
-2. Add the topic to the Hacker News search query (check out [Algolia's REST API](https://www.algolia.com/doc/api-reference/rest-api) for more details)
-3. Return all the new articles related to the topic that were published since the last check
+1. Extract the topic from the Slack app mention.
+2. Add the topic to the Hacker News search query (check out [Algolia's REST API](https://www.algolia.com/doc/api-reference/rest-api) for more details).
+3. Return all the new articles related to the topic that were published since the last check.
 
 ## Deployment & Configuration
 
@@ -59,5 +59,5 @@ This project monitors Hacker News for new articles matching a specific topic, fe
 
 ## Trigger Workflow
 
-- Type `/your-slack-app topic` in the Slack channel you set in the environment variable, replacing `topic` with what you want to search for, to start tracking articles
+- Type `@your-slack-app topic` in the Slack channel you set in the environment variable, replacing `topic` with what you want to search for, to start tracking articles
 - The workflow runs automatically every two minutes after deployment

--- a/hackernews/README.md
+++ b/hackernews/README.md
@@ -15,7 +15,6 @@ This project monitors Hacker News for new articles matching a specific topic, fe
 2. Add the topic to the Hacker News search query (check out [Algolia's REST API](https://www.algolia.com/doc/api-reference/rest-api) for more details)
 3. Return all the new articles related to the topic that were published since the last check
 
-
 ## Deployment & Configuration
 
 ### Cloud Usage (Recommended)

--- a/hackernews/README.md
+++ b/hackernews/README.md
@@ -11,9 +11,9 @@ This project monitors Hacker News for new articles matching a specific topic, fe
 
 ## How It Works
 
-1. Reads the topic from the Slack command.
-2. Adds the topic to the search query of HackerNews. Check out https://www.algolia.com/doc/api-reference/rest-api for more details. 
-3. Returns the new articles related to the topic that are published after the code started.
+1. Read the topic from the Slack command
+2. Add the topic to the Hacker News search query (check out [Algolia's REST API](https://www.algolia.com/doc/api-reference/rest-api) for more details)
+3. Return all the new articles related to the topic that were published since the last check
 
 
 ## Deployment & Configuration

--- a/hackernews/README.md
+++ b/hackernews/README.md
@@ -1,5 +1,5 @@
 ---
-title: Hackernews Alert with Slack 
+title: Hackernews Alert in Slack 
 description: A bot that tracks Hacker News articles by topic and sends updates to Slack.
 integrations: ["slack"]
 categories: ["Office Automation"]

--- a/hackernews/README.md
+++ b/hackernews/README.md
@@ -5,7 +5,7 @@ integrations: ["slack"]
 categories: ["Office Automation"]
 ---
 
-# Hackernews Slack Sample
+# Hacker News Alerts in Slack
 
 This project monitors Hacker News for new articles matching a specific topic, fetching their details in real-time. It compares the latest results with previously fetched articles to identify new ones and sends their title and URL as notifications to a Slack channel.
 

--- a/hackernews/README.md
+++ b/hackernews/README.md
@@ -19,7 +19,7 @@ This project monitors Hacker News for new articles matching a specific topic, fe
 
 ### Cloud Usage (Recommended)
 
-- Initialize your connection with slack through the UI
+- Initialize your connection with Slack through the UI
 
 
 ## Trigger Workflow

--- a/hackernews/README.md
+++ b/hackernews/README.md
@@ -27,6 +27,7 @@ This project monitors Hacker News for new articles matching a specific topic, fe
 - The workflow runs automatically every two minutes after deployment
 
 #### Prerequisites
+
 - [Install AutoKitteh](https://docs.autokitteh.com/get_started/install)
 - Set up required integrations:
   - [Slack](https://docs.autokitteh.com/integrations/slack)

--- a/hackernews/README.md
+++ b/hackernews/README.md
@@ -23,7 +23,7 @@ This project monitors Hacker News for new articles matching a specific topic, fe
 
 ## Trigger Workflow
 
-- Type `/your_slack_app` `topic` in the Slack channel you set in the environment variable, replacing `topic` with what you want to search for, to start tracking articles.
+- Type `/your-slack-app topic` in the Slack channel you set in the environment variable, replacing `topic` with what you want to search for, to start tracking articles
 - The workflow runs automatically every two minutes after deployment. 
 
 #### Prerequisites

--- a/hackernews/README.md
+++ b/hackernews/README.md
@@ -5,7 +5,6 @@ integrations: ["slack"]
 categories: ["Office Automation"]
 ---
 
-
 # Hackernews Slack Sample
 
 This project monitors Hacker News for new articles matching a specific topic, fetching their details in real-time. It compares the latest results with previously fetched articles to identify new ones and sends their title and URL as notifications to a Slack channel.

--- a/hackernews/README.md
+++ b/hackernews/README.md
@@ -1,5 +1,5 @@
 ---
-title: Hackernews Alert in Slack 
+title: Hacker News Alerts in Slack 
 description: Track Hacker News articles by topic and send updates to Slack
 integrations: ["slack"]
 categories: ["Office Automation"]

--- a/hackernews/README.md
+++ b/hackernews/README.md
@@ -10,18 +10,56 @@ categories: ["Office Automation"]
 
 This project monitors Hacker News for new articles matching a specific topic, fetching their details in real-time. It compares the latest results with previously fetched articles to identify new ones and sends their title and URL as notifications to a Slack channel.
 
-## API Documentation
+## How It Works
 
-- Slack connection. https://docs.autokitteh.com/integrations/slack.
-- Fetches articles from Hacker News. https://www.algolia.com/doc/api-reference/rest-api.
+1. Reads the topic from the Slack command.
+2. Adds the topic to the search query of HackerNews. Check out https://www.algolia.com/doc/api-reference/rest-api for more details. 
+3. Returns the new articles related to the topic that are published after the code started.
 
-## Setup Instructions
 
-1. Set the `SLACK_CHANNEL` environment value
+## Deployment & Configuration
 
-2. Via the ak CLI tool or the AutoKitteh VS Code extension, deploy the autokitteh.yaml manifest file, or you can use the cloud version for easy deployment and management.
+### Cloud Usage (Recommended)
 
-## Usage Instruction 
+- Initialize your connection with slack through the UI
+
+
+## Trigger Workflow
 
 - Type `/your_slack_app` `topic` in the Slack channel you set in the environment variable, replacing `topic` with what you want to search for, to start tracking articles.
+- The workflow runs automatically every two minutes after deployment. 
+
+#### Prerequisites
+- [Install AutoKitteh](https://docs.autokitteh.com/get_started/install)
+- Set up required integrations:
+  - [Slack](https://docs.autokitteh.com/integrations/slack)
+
+#### Installation Steps
+1. Clone the repository:
+   ```shell
+   git clone https://github.com/autokitteh/kittehub.git
+   cd kittehub/hackernews
+   ```
+
+2. Start the AutoKitteh server:
+   ```shell
+   ak up --mode dev
+   ```
+
+3. Deploy the project:
+   ```shell
+   ak deploy --manifest autokitteh.yaml
+   ```
+
+   The output will show your connection IDs, which you'll need for the next step. Look for lines like:
+   ```shell
+   [exec] create_connection "hackernews_alert/slack_connection": con_01je39d6frfdtshstfg5qpk8sz created
+   ```
+   
+   In this example, `con_01je39d6frfdtshstfg5qpk8sz` is the connection ID.
+
+4. Initialize your connections using the CLI:
+   ```shell
+   ak connection init slack_connection <connection ID>
+   ```
 

--- a/hackernews/README.md
+++ b/hackernews/README.md
@@ -1,6 +1,6 @@
 ---
 title: Hackernews Alert in Slack 
-description: A bot that tracks Hacker News articles by topic and sends updates to Slack.
+description: Track Hacker News articles by topic and send updates to Slack
 integrations: ["slack"]
 categories: ["Office Automation"]
 ---

--- a/hackernews/README.md
+++ b/hackernews/README.md
@@ -17,14 +17,9 @@ This project monitors Hacker News for new articles matching a specific topic, fe
 
 ## Deployment & Configuration
 
-### Cloud Usage (Recommended)
+#### Cloud Usage (Recommended)
 
 - Initialize your connection with Slack through the UI
-
-## Trigger Workflow
-
-- Type `/your-slack-app topic` in the Slack channel you set in the environment variable, replacing `topic` with what you want to search for, to start tracking articles
-- The workflow runs automatically every two minutes after deployment
 
 #### Prerequisites
 
@@ -33,6 +28,7 @@ This project monitors Hacker News for new articles matching a specific topic, fe
   - [Slack](https://docs.autokitteh.com/integrations/slack)
 
 #### Installation Steps
+
 1. Clone the repository:
    ```shell
    git clone https://github.com/autokitteh/kittehub.git
@@ -61,3 +57,7 @@ This project monitors Hacker News for new articles matching a specific topic, fe
    ak connection init slack_connection <connection ID>
    ```
 
+## Trigger Workflow
+
+- Type `/your-slack-app topic` in the Slack channel you set in the environment variable, replacing `topic` with what you want to search for, to start tracking articles
+- The workflow runs automatically every two minutes after deployment

--- a/hackernews/README.md
+++ b/hackernews/README.md
@@ -21,7 +21,6 @@ This project monitors Hacker News for new articles matching a specific topic, fe
 
 - Initialize your connection with Slack through the UI
 
-
 ## Trigger Workflow
 
 - Type `/your_slack_app` `topic` in the Slack channel you set in the environment variable, replacing `topic` with what you want to search for, to start tracking articles.

--- a/hackernews/autokitteh.yaml
+++ b/hackernews/autokitteh.yaml
@@ -1,0 +1,15 @@
+version: v1
+
+project:
+  name: hackernews_alert
+  vars:
+    - name: SLACK_CHANNEL
+      value: 
+  connections:
+    - name: slack_connection
+      integration: slack
+  triggers:
+    - name: slack_slash_command
+      connection: slack_connection
+      event_type: slash_command
+      call: program.py:on_command

--- a/hackernews/autokitteh.yaml
+++ b/hackernews/autokitteh.yaml
@@ -1,5 +1,5 @@
-# This YAML file is a declarative manifest that describes the setup of
-# an AutoKitteh project that fetches hackernews articles for a specific topic
+# This YAML file is a declarative manifest that describes the setup of an
+# AutoKitteh project that monitors Hacker News for a specific topic.
 
 version: v1
 

--- a/hackernews/autokitteh.yaml
+++ b/hackernews/autokitteh.yaml
@@ -5,6 +5,9 @@ version: v1
 
 project:
   name: hackernews_alert
+  vars:
+    - name: POLLING_INTERVAL_SECS
+      value: 120
   connections:
     - name: slack_connection
       integration: slack

--- a/hackernews/autokitteh.yaml
+++ b/hackernews/autokitteh.yaml
@@ -5,14 +5,11 @@ version: v1
 
 project:
   name: hackernews_alert
-  vars:
-    - name: SLACK_CHANNEL
-      value: 
   connections:
     - name: slack_connection
       integration: slack
   triggers:
     - name: slack_slash_command
       connection: slack_connection
-      event_type: slash_command
+      event_type: app_mention
       call: program.py:on_slack_command

--- a/hackernews/autokitteh.yaml
+++ b/hackernews/autokitteh.yaml
@@ -1,3 +1,6 @@
+# This YAML file is a declarative manifest that describes the setup of
+# an AutoKitteh project that fetches hackernews articles for a specific topic
+
 version: v1
 
 project:
@@ -12,4 +15,4 @@ project:
     - name: slack_slash_command
       connection: slack_connection
       event_type: slash_command
-      call: program.py:on_command
+      call: program.py:on_slack_command

--- a/hackernews/program.py
+++ b/hackernews/program.py
@@ -1,5 +1,4 @@
-"""This project monitors Hacker News for new articles on a specific topic provided via a Slack command
-and posts updates to a Slack channel in real-time."""
+"""Monitor Hacker News for new articles on a specific topic, and post updates to a Slack channel."""
 
 import os
 import requests

--- a/hackernews/program.py
+++ b/hackernews/program.py
@@ -1,0 +1,45 @@
+import os
+import requests
+import time
+import urllib.parse
+
+from autokitteh.slack import slack_client
+
+
+slack = slack_client("slack_connection")
+SLACK_CHANNEL = os.getenv("SLACK_CHANNEL")
+
+
+def on_command(event):
+    topic = event.data.text  # Extract the topic from the Slack command
+    existing_articles = set()
+    fetch_articles(topic, existing_articles)
+
+    while True:
+        all_articles = set(existing_articles)
+        fetch_articles(topic, all_articles)
+        new_articles = all_articles - existing_articles
+
+        if new_articles:
+            for article in new_articles:
+                _, title, url = article
+                s_message = f"Title: {title}, URL: {url if url else 'No URL'}"
+                print(s_message)
+                slack.chat_postMessage(channel=SLACK_CHANNEL, text=s_message)
+            existing_articles.update(new_articles)
+
+        time.sleep(120)
+
+
+def fetch_articles(topic, all_articles):
+    encoded_query = urllib.parse.quote(topic)
+    full_url = f"http://hn.algolia.com/api/v1/search_by_date?query={encoded_query}&tags=story&page=0"
+    response = requests.get(full_url).json()
+    hits = response["hits"]
+
+    # Extract some of the article fields from API response
+    for article in hits:
+        object_id = article["objectID"]
+        title = article["title"]
+        url = article.get("url")
+        all_articles.add((object_id, title, url))

--- a/hackernews/program.py
+++ b/hackernews/program.py
@@ -49,7 +49,7 @@ def fetch_articles(topic, all_articles):
     full_url = f"http://hn.algolia.com/api/v1/search_by_date?query={encoded_query}&tags=story&page=0"
     hits = requests.get(full_url).json().get("hits", [])
 
-    # Extract some of the article fields from API response
+    # Extract some of the article fields from the API response.
     for article in hits:
         object_id = article["objectID"]
         title = article["title"]

--- a/hackernews/program.py
+++ b/hackernews/program.py
@@ -19,7 +19,7 @@ def on_slack_command(event):
     Extracts a topic from a Slack command, monitors for new articles,
     and posts updates to `SLACK_CHANNEL`.
     """
-    topic = event.data.text.split(" ", 1)[1].strip()
+    topic = event.data.text.split(" ", 1)[-1].strip()
     slack.chat_postMessage(
         channel=event.data.channel,
         text=f"Waiting for new articles on the topic: `{topic}`.",

--- a/hackernews/program.py
+++ b/hackernews/program.py
@@ -22,7 +22,7 @@ def on_slack_command(event):
     """
     topic = event.data.text
     slack.chat_postMessage(
-        channel=SLACK_CHANNEL, text=f"Waiting for new articles on the topic: {topic}."
+        channel=SLACK_CHANNEL, text=f"Waiting for new articles on the topic: `{topic}`."
     )
     current_articles = set()
     fetch_articles(topic, current_articles)

--- a/hackernews/program.py
+++ b/hackernews/program.py
@@ -8,9 +8,10 @@ import urllib.parse
 from autokitteh.slack import slack_client
 
 
-slack = slack_client("slack_connection")
-SLACK_CHANNEL = os.getenv("SLACK_CHANNEL")
 API_URL = "http://hn.algolia.com/api/v1/search_by_date?tags=story&page=0&query="
+POLLING_INTERVAL_SECS = int(os.getenv("POLLING_INTERVAL_SECS"))
+
+slack = slack_client("slack_connection")
 
 
 def on_slack_command(event):
@@ -39,7 +40,7 @@ def on_slack_command(event):
             slack.chat_postMessage(channel=event.data.channel, text=slack_message)
         current_articles.update(new_articles)
 
-        time.sleep(120)
+        time.sleep(POLLING_INTERVAL_SECS)
 
 
 def fetch_articles(topic, all_articles):

--- a/hackernews/program.py
+++ b/hackernews/program.py
@@ -47,8 +47,7 @@ def on_slack_command(event):
 def fetch_articles(topic, all_articles):
     encoded_query = urllib.parse.quote(topic)
     full_url = f"http://hn.algolia.com/api/v1/search_by_date?query={encoded_query}&tags=story&page=0"
-    response = requests.get(full_url).json()
-    hits = response["hits"]
+    hits = requests.get(full_url).json().get("hits", [])
 
     # Extract some of the article fields from API response
     for article in hits:

--- a/hackernews/program.py
+++ b/hackernews/program.py
@@ -14,11 +14,9 @@ API_URL = "http://hn.algolia.com/api/v1/search_by_date?tags=story&page=0&query="
 
 
 def on_slack_command(event):
-    """
-    Workflow's entry-point.
-
-    extract a topic from a Slack command, monitors for new articles,
-    and posts updates to the Slack channel.
+    """Workflow's entry-point.
+    Extracts a topic from a Slack command, monitors for new articles,
+    and posts updates to `SLACK_CHANNEL`.
     """
     topic = event.data.text.split(" ", 1)[1].strip()
     slack.chat_postMessage(


### PR DESCRIPTION
This PR addresses ENG-1025. Project tracks articles from Hacker News based on user-provided topic and sends updates to a designated Slack channel. The main functionality includes:
	•	Slash Command Integration: Users can specify a topic to monitor directly from Slack.
	•	Real-Time Updates: The bot fetches new articles every two minutes and posts any updates to Slack.
	•	Hacker News API Integration: Uses the Algolia-powered Hacker News API to search for articles by keyword.
	•	Slack Integration: Sends article details (title and URL) to the specified Slack channel.

Since we’re updating the README to focus on cloud deployment,  I did not place significant emphasis on the README file