### PR TITLE
feat: migrate Purrr to Python (part 1)

### DIFF
--- a/purrr/README.md
+++ b/purrr/README.md
@@ -1,0 +1,58 @@
+---
+title: Pull Request Review Reminder (Purrr)
+description: Streamline code reviews and cut down turnaround time to merge pull requests
+integrations: ["GitHub", "Google Sheets", "Slack"]
+categories: ["DevOps"]
+---
+
+# Pull Request Review Reminder (Purrr)
+
+Purrr integrates GitHub and Slack seamlessly, to streamline code reviews and
+cut down the turnaround time to merge pull requests.
+
+- Real-time, relevant, informative, 2-way updates
+- Easier collaboration and faster execution
+- Free and open-source
+
+No more:
+
+- Delays due to missed requests, comments, and state changes
+- Notification fatigue due to updates that don't concern you
+- Qestions like "Who's turn is it" or "What should I do now"
+
+All that and more is implemented with a few hundred lines of Python.
+AutoKitteh takes care of all the system infrastructure and reliability needs.
+
+## Slack Usage
+
+Event-based, 2-way synchronization:
+
+- Slack channels are created and archived automatically for each PR
+- Stakeholders are added and removed automatically in Slack and GitHub
+- Reviews, comments, conversation threads, and emoji reactions are updated in
+  both directions
+
+User matching between GitHub and Slack is based on email addresses and
+case-insensitive full names.
+
+Available Slack slash commands:
+
+- `/purrr help`
+- `/purrr opt-in`
+- `/purrr opt-out`
+- `/purrr list`
+- `/purrr status [PR]`
+- `/purrr approve [PR]`
+
+## Data Storage
+
+Purrr uses a simple Google Sheet for:
+
+1. Mapping between GitHub PRs and Slack channels
+2. Mapping between GitHub comments/reviews and Slack message threads
+3. Caching user IDs (optimization to reduce API calls)
+4. User opt-out database
+
+Use-cases 1 and 2 use a TTL of 30 days (configurable in the `autokitteh.yaml`
+manifest file). Use-case 3 uses a TTL of one day since the last cache hit.
+Use-case 4 is permanent (until the user opts back in).

--- a/purrr/README.md
+++ b/purrr/README.md
@@ -18,7 +18,7 @@ No more:
 
 - Delays due to missed requests, comments, and state changes
 - Notification fatigue due to updates that don't concern you
-- Qestions like "Who's turn is it" or "What should I do now"
+- Questions like "Who's turn is it" or "What should I do now"
 
 All that and more is implemented with a few hundred lines of Python.
 AutoKitteh takes care of all the system infrastructure and reliability needs.

--- a/purrr/autokitteh.yaml
+++ b/purrr/autokitteh.yaml
@@ -1,0 +1,69 @@
+# This YAML file is a declarative manifest that describes the setup
+# of the AutoKitteh project "Pull Request Review Reminder" (Purrr).
+# Purrr integrates GitHub and Slack seamlessly, to streamline code
+# reviews and cut down the turnaround time to merge pull requests.
+
+version: v1
+
+project:
+  name: purrr
+
+  vars:
+    # Temporary (easy to debug, but not scalable) replacement for Redis/Valkey.
+    - name: DATA_SHEET_URL
+      value: TODO
+    # PR channel names in Slack: "<prefix>_<number>_<title>".
+    - name: SLACK_CHANNEL_PREFIX
+      value: _pr
+    # Visibility of PR channels in Slack: "public" (default) or "private".
+    - name: SLACK_CHANNEL_VISIBILITY
+      value: public
+    # Create this channel / replace with your own / set to "" to disable it.
+    - name: SLACK_DEBUG_CHANNEL
+      value: purrr-debug
+    # TTL for GitHub/Slack mappings = 30 days (to forget stale PRs).
+    - name: STATE_TTL
+      value: 720h
+
+  connections:
+    - name: github_conn
+      integration: github
+    - name: sheets_conn
+      integration: googlesheets
+    - name: slack_conn
+      integration: slack
+
+  triggers:
+    # - name: github_issue_comment
+    #   connection: github_conn
+    #   event_type: issue_comment
+    #   call: github_issue_comment.py:on_github_issue_comment
+    - name: github_pull_request
+      connection: github_conn
+      event_type: pull_request
+      call: github_pr.py:on_github_pull_request
+    # - name: github_pull_request_review
+    #   connection: github_conn
+    #   event_type: pull_request_review
+    #   call: github_pr_review.py:on_github_pull_request_review
+    # - name: github_pull_request_review_comment
+    #   connection: github_conn
+    #   event_type: pull_request_review_comment
+    #   call: github_review_comment.py:on_github_pull_request_review_comment
+    # - name: github_pull_request_review_thread
+    #   connection: github_conn
+    #   event_type: pull_request_review_thread
+    #   call: github_thread.py:on_github_pull_request_review_thread
+
+    # - name: slack_message
+    #   connection: slack_conn
+    #   event_type: message
+    #   call: slack_message.py:on_slack_message
+    # - name: slack_reaction_added
+    #   connection: slack_conn
+    #   event_type: reaction_added
+    #   call: slack_reaction.py:on_slack_reaction_added
+    - name: slack_slash_command
+      connection: slack_conn
+      event_type: slash_command
+      call: slack_cmd.py:on_slack_slash_command

--- a/purrr/data_helper.py
+++ b/purrr/data_helper.py
@@ -1,0 +1,48 @@
+"""Thin wrapper over the Google Sheets API for data management and caching.
+
+Redis/Valkey would be a better choice, but are not available at this time.
+"""
+
+from datetime import datetime
+
+
+# Cache user lookup results for a day, to reduce the amount
+# of API calls (especially to Slack), to avoid throttling.
+_USER_CACHE_TTL = "24h"
+
+
+def cache_slack_user_id(github_username: str, slack_user_id: str) -> None:
+    """Map a GitHub username to a Slack user ID, for a day.
+
+    This helps reduce the amount of Slack lookup API calls, to avoid throttling.
+    """
+    return  # TODO: Implement this function.
+
+
+def cached_slack_user_id(github_username: str) -> str:
+    """Return the Slack user ID mapped to a GitHub user, if it's already cached.
+
+    This helps reduce the amount of Slack lookup API calls, to avoid throttling.
+
+    Args:
+        github_username: GitHub username to look-up.
+
+    Returns:
+        Slack user ID, or "" if not found.
+    """
+    return ""  # TODO: Implement this function.
+
+
+def slack_opt_in(user_id: str) -> None:
+    """Delete the opt-out timestamp for a Slack user."""
+    return  # TODO: Implement this function.
+
+
+def slack_opt_out(user_id: str) -> None:
+    """Return the opt-out timestamp for a Slack user, or None if they're opted-in."""
+    return  # TODO: Implement this function.
+
+
+def slack_opted_out(user_id: str) -> datetime | None:
+    """Return the opt-out timestamp for a Slack user, or None if they're opted-in."""
+    return None  # TODO: Implement this function.

--- a/purrr/github_helper.py
+++ b/purrr/github_helper.py
@@ -1,0 +1,6 @@
+"""Thin layer of logic on top of the GitHub API."""
+
+from autokitteh.github import github_client
+
+
+shared_client = github_client("github_conn")

--- a/purrr/github_pr.py
+++ b/purrr/github_pr.py
@@ -1,0 +1,288 @@
+"""Handler for GitHub "pull_request" events."""
+
+import autokitteh
+
+import slack_channel
+
+
+def on_github_pull_request(event) -> None:
+    """Entry-point for AutoKitteh sessions triggered by GitHub "pull_request" events.
+
+    Args:
+        event: GitHub event data.
+    """
+    _parse_github_pr_event(event.data)
+
+
+def _parse_github_pr_event(data) -> None:
+    """Parse a GitHub "pull_request" event and dispatch the appropriate handler.
+
+    About GitHub pull requests and these events:
+    - https://docs.github.com/webhooks/webhook-events-and-payloads#pull_request
+    - https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests
+
+    Args:
+        data: GitHub event data.
+    """
+    match data.action:
+        # A new pull request was created.
+        case "opened":
+            _on_pr_opened(data)
+        # A pull request was closed.
+        case "closed":
+            _on_pr_closed(data)
+        # A previously closed pull request was reopened.
+        case "reopened":
+            _on_pr_reopened(data)
+
+        # A pull request was converted to a draft.
+        case "converted_to_draft":
+            _on_pr_converted_to_draft(data)
+        # A draft pull request was marked as ready for review.
+        case "ready_for_review":
+            _on_pr_ready_for_review(data)
+
+        # Review by a person or team was requested for a pull request.
+        case "review_requested":
+            _on_pr_review_requested(data)
+        # A request for review by a person or team was removed from a pull request.
+        case "review_request_removed":
+            _on_pr_review_request_removed(data)
+
+        # A pull request was assigned to a user.
+        case "assigned":
+            _on_pr_assigned(data)
+        # A user was unassigned from a pull request.
+        case "unassigned":
+            _on_pr_unassigned(data)
+
+        # The title or body of a pull request was edited, or the base branch was changed.
+        case "edited":
+            _on_pr_edited(data)
+        # A pull request's head branch was updated.
+        case "synchronize":
+            _on_pr_synchronized(data)
+
+        # TODO: locked, unlocked
+
+        # Ignored actions:
+        # - auto_merge_enabled, auto_merge_disabled
+        # - enqueued, dequeued
+        # - labeled, unlabeled
+        # - milestoned, demilestoned
+
+
+def _on_pr_opened(data) -> None:
+    """A new pull request was created (or reopened, or marked as ready for review).
+
+    See also the functions "_on_pr_reopened" and "_on_pr_ready_for_review".
+
+    Args:
+        data: GitHub event data.
+    """
+    # Ignore drafts until they're marked as ready for review.
+    if data.pull_request.draft:
+        return
+
+    slack_channel.initialize_for_github_pr(data.action, data.pull_request)
+
+    # Keep an AutoKitteh session running as long as the PR is alive.
+    github_subs = autokitteh.subscribe(
+        "github_conn", filter="event_type == 'pull_request'"
+    )
+    while True:
+        data = autokitteh.next_event([github_subs])
+        print("Received GitHub PR event:", data.action)
+        if data.action in ("closed", "converted_to_draft"):
+            _parse_github_pr_event(data)
+            autokitteh.unsubscribe(github_subs)
+            break
+
+
+def _on_pr_closed(data) -> None:
+    """A pull request (possibly a draft) was closed.
+
+    If "merged" is false in the webhook payload, the pull request was
+    closed with unmerged commits. If "merged" is true in the webhook
+    payload, the pull request was merged.
+
+    Args:
+        data: GitHub event data.
+    """
+    # Ignore drafts - they don't have an active Slack channel anyway.
+    if data.pull_request.draft:
+        return
+
+    pass  # TODO: Implement this function.
+
+
+def _on_pr_reopened(data) -> None:
+    """A previously closed pull request (possibly a draft) was reopened.
+
+    Slack bug alert from https://api.slack.com/methods/conversations.unarchive:
+    bot tokens ("xoxb-...") cannot currently be used to unarchive conversations.
+    For now, please use a user token ("xoxp-...") to unarchive the conversation
+    rather than a bot token.
+
+    Args:
+        data: GitHub event data.
+    """
+    # Ignore drafts - they don't have an active Slack channel anyway.
+    if data.pull_request.draft:
+        return
+
+    # Workaround for the Slack unarchive bug: treat this as a new PR.
+    _on_pr_opened(data)
+
+
+def _on_pr_converted_to_draft(data) -> None:
+    """A pull request was converted to a draft.
+
+    For more information, see "Changing the stage of a pull request":
+    https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
+
+    Args:
+        data: GitHub event data.
+    """
+    pass  # TODO: Implement this function.
+
+
+def _on_pr_ready_for_review(data) -> None:
+    """A draft pull request was marked as ready for review.
+
+    For more information, see "Changing the stage of a pull request":
+    https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request
+
+    Slack bug alert from https://api.slack.com/methods/conversations.unarchive:
+    bot tokens ("xoxb-...") cannot currently be used to unarchive conversations.
+    For now, please use a user token ("xoxp-...") to unarchive the conversation
+    rather than a bot token.
+
+    Args:
+        data: GitHub event data.
+    """
+    # Workaround for the Slack unarchive bug: treat this as a new PR.
+    _on_pr_opened(data)
+
+
+def _on_pr_review_requested(data) -> None:
+    """Review by a person or team was requested for a pull request.
+
+    For more information, see "Requesting a pull request review":
+    https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review
+
+    Args:
+        data: GitHub event data.
+    """
+    # Don't do anything if there isn't an active Slack channel anyway.
+    if data.pull_request.draft or data.pull_request.state != "open":
+        return
+
+    pass  # TODO: Implement this function.
+
+
+def _on_pr_review_requested_person(data, channel_id: str) -> None:
+    """Review by a person was requested for a pull request.
+
+    Args:
+        data: GitHub event data.
+        channel_id: PR's Slack channel ID.
+    """
+    pass  # TODO: Implement this function.
+
+
+def _on_pr_review_requested_team(data, channel_id: str) -> None:
+    """Review by a team was requested for a pull request.
+    Args:
+        data: GitHub event data.
+        channel_id: PR's Slack channel ID.
+    """
+    pass  # TODO: Implement this function.
+
+
+def _on_pr_review_request_removed(data) -> None:
+    """A request for review by a person or team was removed from a pull request.
+
+    Args:
+        data: GitHub event data.
+    """
+    # Don't do anything if there isn't an active Slack channel anyway.
+    if data.pull_request.draft or data.pull_request.state != "open":
+        return
+
+    pass  # TODO: Implement this function.
+
+
+def _on_pr_review_request_removed_person(data, channel_id: str) -> None:
+    """A request for review by a person was removed from a pull request.
+
+    Args:
+        data: GitHub event data.
+        channel_id: PR's Slack channel ID.
+    """
+    pass  # TODO: Implement this function.
+
+
+def _on_pr_review_request_removed_team(data, channel_id: str) -> None:
+    """A request for review by a team was removed from a pull request.
+
+    Args:
+        data: GitHub event data.
+        channel_id: PR's Slack channel ID.
+    """
+    pass  # TODO: Implement this function.
+
+
+def _on_pr_assigned(data) -> None:
+    """A pull request was assigned to a user.
+
+    Args:
+        data: GitHub event data.
+    """
+    # Don't do anything if there isn't an active Slack channel anyway.
+    if data.pull_request.draft or data.pull_request.state != "open":
+        return
+
+    pass  # TODO: Implement this function.
+
+
+def _on_pr_unassigned(data) -> None:
+    """A user was unassigned from a pull request.
+
+    Args:
+        data: GitHub event data.
+    """
+    # Don't do anything if there isn't an active Slack channel anyway.
+    if data.pull_request.draft or data.pull_request.state != "open":
+        return
+
+    pass  # TODO: Implement this function.
+
+
+def _on_pr_edited(data) -> None:
+    """The title or body of a pull request was edited, or the base branch was changed.
+
+    Args:
+        data: GitHub event data.
+    """
+    # Don't do anything if there isn't an active Slack channel anyway.
+    if data.pull_request.draft or data.pull_request.state != "open":
+        return
+
+    pass  # TODO: Implement this function.
+
+
+def _on_pr_synchronized(data) -> None:
+    """A pull request's head branch was updated.
+
+    For example, the head branch was updated from the base
+    branch or new commits were pushed to the head branch.
+
+    Args:
+        data: GitHub event data.
+    """
+    # Don't do anything if there isn't an active Slack channel anyway.
+    if data.pull_request.draft or data.pull_request.state != "open":
+        return
+
+    pass  # TODO: Implement this function.

--- a/purrr/slack_channel.py
+++ b/purrr/slack_channel.py
@@ -1,0 +1,117 @@
+"""Create and manage Slack channels."""
+
+import json
+
+from slack_sdk.errors import SlackApiError
+
+import slack_helper
+import users
+
+
+_MAX_METADATA_LENGTH = 250  # Characters.
+
+
+slack = slack_helper.shared_client
+
+
+def initialize_for_github_pr(action: str, pr) -> None:
+    """Initialize a dedicated Slack channel for a GitHub PR.
+
+    Args:
+        action: GitHub PR event action.
+        pr: GitHub PR data.
+    """
+    # Sanity check the GitHub PR event action.
+    if action not in ("opened", "reopened", "ready_for_review"):
+        error = "Unexpected GitHub PR event action for initializing a Slack channel"
+        slack_helper.debug(f"{error}: `{action}`")
+        raise ValueError(f"{error}: `{action}`")
+
+    print(f"Creating Slack channel for {pr.html_url} (PR event action: {action})")
+    print(json.dumps(pr, indent=2, sort_keys=True))
+
+    name = f"{pr.number}_{slack_helper.normalize_channel_name(pr.title)}"
+    channel_id = slack_helper.create_channel(name)
+    if not channel_id:
+        _report_creation_error(pr)
+        return
+
+    _set_topic(pr, channel_id)
+    _set_description(pr, channel_id)
+    _set_bookmarks(pr, channel_id)
+
+    # TODO: Post an introduction message to the new channel, describing the PR.
+
+    # TODO: Also post a message summarizing check states (updated
+    # later based on "worklfow_job" and "workflow_run" events).
+
+    # TODO: In case this is a replacement Slack channel, say so.
+
+    # TODO: Map between the GitHub PR and the Slack channel ID, for 2-way event syncs.
+
+    # TODO: Finally, add all the participants in the PR to this channel.
+
+
+def _report_creation_error(pr) -> None:
+    github_username = pr.user.login
+    github_org = pr.base.repo.owner.login
+    user_id = users.github_username_to_slack_user_id(github_username, github_org)
+
+    error = "Failed to create Slack channel for " + pr.html_url
+    slack_helper.debug(error)
+    try:
+        slack.chat_postMessage(channel=user_id, text=error)
+    except SlackApiError as e:
+        error = f"Failed to notify <@{user_id}> (`{github_username}` in GitHub)"
+        error += " about failing to create Slack channel for "
+        error += f"{pr.html_url}: `{e.response["error"]}`"
+        slack_helper.debug(error)
+    return
+
+
+def _set_bookmarks(pr, channel_id: str) -> None:
+    """Set the bookmarks of a Slack channel to important PR links.
+
+    Bookmark titles should be updated later based on relevant GitHub events.
+
+    Args:
+        pr: GitHub PR event data.
+        channel_id: Slack channel ID.
+    """
+    pass  # TODO: Implement this function.
+
+
+def _set_description(pr, channel_id: str) -> None:
+    """Set the description of a Slack channel to a GitHub PR title.
+
+    Args:
+        action: GitHub PR event action.
+        pr: GitHub PR event data.
+        channel_id: Slack channel ID.
+    """
+    title = f"`{pr.title}`"
+    if len(title) > _MAX_METADATA_LENGTH:
+        title = title[: _MAX_METADATA_LENGTH - 4] + "`..."
+    try:
+        slack.conversations_setPurpose(channel=channel_id, purpose=title)
+    except SlackApiError as e:
+        error = f"Failed to set the purpose of <#{channel_id}> to `{title}`"
+        slack_helper.debug(error + f": `{e.response['error']}`")
+
+
+def _set_topic(pr, channel_id: str) -> None:
+    """Set the topic of a Slack channel to a GitHub PR URL.
+
+    Args:
+        action: GitHub PR event action.
+        pr: GitHub PR event data.
+        channel_id: Slack channel ID.
+    """
+    topic = pr.html_url
+    if len(topic) > _MAX_METADATA_LENGTH:
+        topic = topic[: _MAX_METADATA_LENGTH - 4] + " ..."
+    try:
+        slack.conversations_setTopic(channel=channel_id, topic=topic)
+    except SlackApiError as e:
+        error = f"Failed to set the topic of <#{channel_id}> to `{topic}`"
+        slack_helper.debug(error + f": `{e.response['error']}`")

--- a/purrr/slack_channel.py
+++ b/purrr/slack_channel.py
@@ -53,20 +53,11 @@ def initialize_for_github_pr(action: str, pr) -> None:
 
 
 def _report_creation_error(pr) -> None:
-    github_username = pr.user.login
-    github_org = pr.base.repo.owner.login
-    user_id = users.github_username_to_slack_user_id(github_username, github_org)
-
+    user_id = users.github_username_to_slack_user_id(pr.user.login)
     error = "Failed to create Slack channel for " + pr.html_url
     slack_helper.debug(error)
-    try:
+    if user_id:
         slack.chat_postMessage(channel=user_id, text=error)
-    except SlackApiError as e:
-        error = f"Failed to notify <@{user_id}> (`{github_username}` in GitHub)"
-        error += " about failing to create Slack channel for "
-        error += f"{pr.html_url}: `{e.response["error"]}`"
-        slack_helper.debug(error)
-    return
 
 
 def _set_bookmarks(pr, channel_id: str) -> None:
@@ -75,7 +66,7 @@ def _set_bookmarks(pr, channel_id: str) -> None:
     Bookmark titles should be updated later based on relevant GitHub events.
 
     Args:
-        pr: GitHub PR event data.
+        pr: GitHub PR data.
         channel_id: Slack channel ID.
     """
     pass  # TODO: Implement this function.
@@ -85,8 +76,7 @@ def _set_description(pr, channel_id: str) -> None:
     """Set the description of a Slack channel to a GitHub PR title.
 
     Args:
-        action: GitHub PR event action.
-        pr: GitHub PR event data.
+        pr: GitHub PR data.
         channel_id: Slack channel ID.
     """
     title = f"`{pr.title}`"
@@ -103,8 +93,7 @@ def _set_topic(pr, channel_id: str) -> None:
     """Set the topic of a Slack channel to a GitHub PR URL.
 
     Args:
-        action: GitHub PR event action.
-        pr: GitHub PR event data.
+        pr: GitHub PR data.
         channel_id: Slack channel ID.
     """
     topic = pr.html_url

--- a/purrr/slack_channel.py
+++ b/purrr/slack_channel.py
@@ -43,7 +43,7 @@ def initialize_for_github_pr(action: str, pr) -> None:
     # TODO: Post an introduction message to the new channel, describing the PR.
 
     # TODO: Also post a message summarizing check states (updated
-    # later based on "worklfow_job" and "workflow_run" events).
+    # later based on "workflow_job" and "workflow_run" events).
 
     # TODO: In case this is a replacement Slack channel, say so.
 

--- a/purrr/slack_cmd.py
+++ b/purrr/slack_cmd.py
@@ -1,0 +1,145 @@
+"""Handler for Slack slash-command events."""
+
+import data_helper
+import slack_helper
+
+
+slack = slack_helper.shared_client
+
+
+def on_slack_slash_command(event):
+    """Entry-point for AutoKitteh sessions triggered by Slack slash-command events.
+
+    - /purrr help
+    - /purrr opt-in
+    - /purrr opt-out
+    - /purrr list
+    - /purrr status [PR]
+    - /purrr approve [PR]
+
+    About slash commands: https://api.slack.com/interactivity/slash-commands
+    See also: https://api.slack.com/interactivity/handling#message_responses
+
+    Args:
+        event: Slack event data.
+    """
+    # Split the command into normalized arguments.
+    data = event.data
+    args = str(data.text).lower().split()
+
+    # Route further processing to the appropriate command handler.
+    if not args or "help" in args:
+        _help(data, args)
+        return
+
+    for cmd, func, _ in _COMMANDS:
+        if cmd == args[0]:
+            func(data, args)
+            return
+
+    error = f"Error: unrecognized Purrr command: `{args[0]}`"
+    slack.chat_postEphemeral(channel=data.channel_id, user=data.user_id, text=error)
+
+
+def _error(data, cmd: str, msg: str):
+    """Send a private error message to the user about their command."""
+    error = f"Error in `{data.command} {cmd}`: {msg}"
+    slack.chat_postEphemeral(channel=data.channel_id, user=data.user_id, text=error)
+
+
+def _help(data, args: list[str]):
+    """Send a private message to the user to list all the available Purrr commands."""
+    if len(args) > 2:
+        # TODO: Support per-command help too, in the future.
+        _error(data, "help", "this command doesn't accept extra arguments")
+        return
+
+    # General help message: a list of all the available commands.
+    text = _help_text(data)
+    slack.chat_postEphemeral(channel=data.channel_id, user=data.user_id, text=text)
+
+
+def _help_text(data) -> str:
+    text = ":wave: *GitHub Pull Request Review Reminder (Purrr)* :wave:\n\n"
+    text += "Available slash commands:"
+    for cmd, _, description in _COMMANDS:
+        text += f"\n  •  `{data.command} {cmd}` - {description}"
+    return text
+
+
+def _opt_in(data, args: list[str]):
+    """User opt-in command handler (this is the default user state)."""
+    if len(args) > 1:
+        _error(data, args[0], "this command doesn't accept extra arguments")
+        return
+
+    if not data_helper.slack_opted_out(data.user_id):
+        msg = ":bell: You're already opted into Purrr"
+        slack.chat_postEphemeral(channel=data.channel_id, user=data.user_id, text=msg)
+        return
+
+    data_helper.slack_opt_in(data.user_id)
+    msg = ":bell: You are now opted into Purrr"
+    slack.chat_postEphemeral(channel=data.channel_id, user=data.user_id, text=msg)
+
+
+def _opt_out(data, args: list[str]):
+    """User opt-out: don't use Purrr even in a Slack workspace that installed it."""
+    if len(args) > 1:
+        _error(data, args[0], "this command doesn't accept extra arguments")
+        return
+
+    opt_out_time = data_helper.slack_opted_out(data.user_id)
+    if opt_out_time:
+        msg = f":no_bell: You're already opted out of Purrr since: {opt_out_time}"
+        slack.chat_postEphemeral(channel=data.channel_id, user=data.user_id, text=msg)
+        return
+
+    data_helper.slack_opt_out(data.user_id)
+    msg = ":no_bell: You are now opted out of Purrr"
+    slack.chat_postEphemeral(channel=data.channel_id, user=data.user_id, text=msg)
+
+
+def _list(data, args: list[str]):
+    """PR list command handler."""
+    if len(args) > 1:
+        _error(data, args[0], "this command doesn't accept extra arguments")
+        return
+
+    error = "Sorry, this command is not implemented yet"
+    slack.chat_postEphemeral(channel=data.channel_id, user=data.user_id, text=error)
+
+
+def _status(data, args: list[str]):
+    """PR status command handler."""
+    # TODO: If the Slack channel belongs to a PR, the arg is optional.
+    if len(args) != 2:
+        msg = "when called outside of a PR channel, this command requires exactly 1 argument - "
+        msg += "an ID of a GitHub PR (`<org>/<repo>/<number>`), or the PR's full URL"
+        _error(data, args[0], msg)
+        return
+
+    error = "Sorry, this command is not implemented yet"
+    slack.chat_postEphemeral(channel=data.channel_id, user=data.user_id, text=error)
+
+
+def _approve(data, args: list[str]):
+    """Approve command."""
+    # TODO: If the Slack channel belongs to a PR, the arg is optional.
+    if len(args) != 2:
+        msg = "when called outside of a PR channel, this command requires exactly 1 argument - "
+        msg += "an ID of a GitHub PR (`<org>/<repo>/<number>`), or the PR's full URL"
+        _error(data, args[0], msg)
+        return
+
+    error = "Sorry, this command is not implemented yet"
+    slack.chat_postEphemeral(channel=data.channel_id, user=data.user_id, text=error)
+
+
+_COMMANDS = [
+    ("opt-in", _opt_in, "Opt into receiving notifications"),
+    ("opt-out", _opt_out, "Opt out of receiving notifications"),
+    ("list", _list, "List all PRs you should pay attention to"),
+    ("status [PR]", _status, "Check the status of a specific PR"),
+    ("approve [PR]", _approve, "Approve a specific PR"),
+]

--- a/purrr/slack_cmd_test.py
+++ b/purrr/slack_cmd_test.py
@@ -1,0 +1,123 @@
+from datetime import datetime
+import unittest
+from unittest.mock import MagicMock
+
+import autokitteh
+
+import slack_cmd
+
+
+class SlackCmdTest(unittest.TestCase):
+    """Unit tests for the "slack_cmd" module."""
+
+    def __init__(self, methodName="runTest"):
+        super().__init__(methodName)
+        self.data = {
+            "channel_id": "purr-debug",
+            "user_id": "user",
+            "command": "/purrr",
+        }
+
+    def setUp(self):
+        slack_cmd.slack = MagicMock()
+        slack_cmd.data_helper = MagicMock()
+        return super().setUp()
+
+    def tearDown(self):
+        return super().tearDown()
+
+    def test_help_text(self):
+        data = autokitteh.AttrDict(self.data)
+        text = slack_cmd._help_text(data)
+
+        for cmd, _, desc in slack_cmd._COMMANDS:
+            self.assertIn(cmd, text)
+            self.assertIn(desc, text)
+
+    def test_on_slack_slash_command_without_text(self):
+        event = autokitteh.AttrDict({"data": self.data | {"text": ""}})
+        slack_cmd.on_slack_slash_command(event)
+
+        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
+            channel=event.data.channel_id,
+            user=event.data.user_id,
+            text=slack_cmd._help_text(event.data),
+        )
+
+    def test_on_slack_slash_command_with_help(self):
+        event = autokitteh.AttrDict({"data": self.data | {"text": "help"}})
+        slack_cmd.on_slack_slash_command(event)
+
+        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
+            channel=event.data.channel_id,
+            user=event.data.user_id,
+            text=slack_cmd._help_text(event.data),
+        )
+
+    def test_on_slack_slash_command_with_noop_opt_in(self):
+        slack_cmd.data_helper.slack_opted_out.return_value = ""
+
+        event = autokitteh.AttrDict({"data": self.data | {"text": "opt-in"}})
+        slack_cmd.on_slack_slash_command(event)
+
+        slack_cmd.data_helper.slack_opted_out.assert_called_once_with(
+            event.data.user_id
+        )
+        slack_cmd.data_helper.slack_opt_in.assert_not_called()
+        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
+            channel=event.data.channel_id,
+            user=event.data.user_id,
+            text=":bell: You're already opted into Purrr",
+        )
+
+    def test_on_slack_slash_command_with_actual_opt_in(self):
+        slack_cmd.data_helper.slack_opted_out.return_value = datetime.min
+
+        event = autokitteh.AttrDict({"data": self.data | {"text": "opt-in"}})
+        slack_cmd.on_slack_slash_command(event)
+
+        slack_cmd.data_helper.slack_opted_out.assert_called_once_with(
+            event.data.user_id
+        )
+        slack_cmd.data_helper.slack_opt_in.assert_called_once_with(event.data.user_id)
+        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
+            channel=event.data.channel_id,
+            user=event.data.user_id,
+            text=":bell: You are now opted into Purrr",
+        )
+
+    def test_on_slack_slash_command_with_noop_opt_out(self):
+        slack_cmd.data_helper.slack_opted_out.return_value = datetime.min
+
+        event = autokitteh.AttrDict({"data": self.data | {"text": "opt-out"}})
+        slack_cmd.on_slack_slash_command(event)
+
+        slack_cmd.data_helper.slack_opted_out.assert_called_once_with(
+            event.data.user_id
+        )
+        slack_cmd.data_helper.slack_opt_out.assert_not_called()
+        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
+            channel=event.data.channel_id,
+            user=event.data.user_id,
+            text=":no_bell: You're already opted out of Purrr since: 0001-01-01 00:00:00",
+        )
+
+    def test_on_slack_slash_command_with_second_opt_out(self):
+        slack_cmd.data_helper.slack_opted_out.return_value = ""
+
+        event = autokitteh.AttrDict({"data": self.data | {"text": "opt-out"}})
+        slack_cmd.on_slack_slash_command(event)
+
+        slack_cmd.data_helper.slack_opted_out.assert_called_once_with(
+            event.data.user_id
+        )
+        slack_cmd.data_helper.slack_opt_out.assert_called_once_with(event.data.user_id)
+        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
+            channel=event.data.channel_id,
+            user=event.data.user_id,
+            text=":no_bell: You are now opted out of Purrr",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/purrr/slack_cmd_test.py
+++ b/purrr/slack_cmd_test.py
@@ -30,9 +30,9 @@ class SlackCmdTest(unittest.TestCase):
         data = autokitteh.AttrDict(self.data)
         text = slack_cmd._help_text(data)
 
-        for cmd, _, desc in slack_cmd._COMMANDS:
-            self.assertIn(cmd, text)
-            self.assertIn(desc, text)
+        for cmd in slack_cmd._COMMANDS.values():
+            self.assertIn(cmd.label, text)
+            self.assertIn(cmd.description, text)
 
     def test_on_slack_slash_command_without_text(self):
         event = autokitteh.AttrDict({"data": self.data | {"text": ""}})

--- a/purrr/slack_helper.py
+++ b/purrr/slack_helper.py
@@ -1,0 +1,108 @@
+"""Thin layer of logic on top of the Slack API."""
+
+import os
+import re
+import traceback
+
+from autokitteh.slack import slack_client
+from slack_sdk.errors import SlackApiError
+
+
+_DEBUG_CHANNEL = os.getenv("SLACK_DEBUG_CHANNEL")
+# PR channel names in Slack: "<prefix>_<number>_<title>".
+_CHANNEL_PREFIX = os.getenv("SLACK_CHANNEL_PREFIX", "_pr")
+# Visibility of PR channels in Slack: "public" (default) or "private".
+_IS_PRIVATE = os.getenv("SLACK_CHANNEL_VISIBILITY") or ""
+
+shared_client = slack_client("slack_conn")
+
+
+def create_channel(name: str) -> str:
+    """Create a public or private Slack channel.
+
+    If the name is already taken, add a numeric suffix to it.
+
+    Args:
+        name: Desired (and valid) name of the channel.
+
+    Returns:
+        Channel ID, or an empty string in case of an error.
+    """
+    is_private = _IS_PRIVATE.lower().strip() == "private"
+    visibility = "private" if is_private else "public"
+    suffix = 0
+
+    while True:
+        suffix += 1
+        n = _CHANNEL_PREFIX + "_" + name if suffix == 1 else f"{name}_{suffix}"
+        try:
+            resp = shared_client.conversations_create(name=n, is_private=is_private)
+            channel_id = resp["channel"]["id"]
+            print(f"Created {visibility} Slack channel {n!r} ({channel_id})")
+            return channel_id
+        except SlackApiError as e:
+            if e.response["error"] != "name_taken":
+                error = f"Failed to create {visibility} Slack channel `{n}`"
+                debug(f"{error}: `{e.response["error"]}`")
+                return ""
+
+
+def debug(msg: str) -> None:
+    """Post a debug message to a predefined Slack channel, if defined.
+
+    Also post a filtered traceback, as replies to the message.
+
+    Args:
+        msg: Message to post.
+    """
+    if not _DEBUG_CHANNEL or not msg:
+        return
+
+    print("DEBUG:", msg)
+    c = _DEBUG_CHANNEL
+    try:
+        resp = shared_client.chat_postMessage(channel=c, text=msg)
+        ts = resp["ts"]
+
+        for file, line, func, text in traceback.extract_stack():
+            # Log only frame summaries relating to this project, up to this function.
+            if "/ak-user-" not in file or func == "debug":
+                continue
+            # Display shorter and cleaner paths.
+            file = re.sub(r'[^"]+/ak-user-.+?/', "", file)
+            msg = f"```File: {file}, line {line}\nFunc: {func}\n{text}```"
+            shared_client.chat_postMessage(channel=c, thread_ts=ts, text=msg)
+
+    except SlackApiError as e:
+        print(f"DEBUG ERROR: {e}")
+
+
+def normalize_channel_name(name: str) -> str:
+    """Convert arbitrary text into a valid Slack channel name.
+
+    Args:
+        name: Desired name for a Slack channel.
+
+    Returns:
+        Valid Slack channel name.
+    """
+    if name == "":
+        return name
+
+    name = name.lower().strip()
+    name = re.sub(r"['\"]", "", name)  # Remove quotes.
+    name = re.sub(r"[^a-z0-9_-]", "-", name)  # Replace invalid characters.
+    name = re.sub(r"[_-]{2,}", "-", name)  # Remove repeating separators.
+
+    # Slack channel names are limited to 80 characters, but that's
+    # too long for comfort, so we use 50 instead. Plus, we need to
+    # leave room for a PR number prefix and a uniqueness suffix.
+    name = name[:50]
+
+    # Cosmetic tweak: remove leading and trailing hyphens.
+    if name[0] == "-":
+        name = name[1:]
+    if name[-1] == "-":
+        name = name[:-1]
+
+    return name

--- a/purrr/slack_helper.py
+++ b/purrr/slack_helper.py
@@ -69,7 +69,7 @@ def debug(msg: str) -> None:
             if "/ak-user-" not in file or func == "debug":
                 continue
             # Display shorter and cleaner paths.
-            file = re.sub(r'[^"]+/ak-user-.+?/', "", file)
+            file = re.sub(r"^.+/ak-user-.+?/", "", file)
             msg = f"```File: {file}, line {line}\nFunc: {func}\n{text}```"
             shared_client.chat_postMessage(channel=c, thread_ts=ts, text=msg)
 

--- a/purrr/slack_helper_test.py
+++ b/purrr/slack_helper_test.py
@@ -1,0 +1,21 @@
+import unittest
+
+import slack_helper
+
+
+class SlackHelperTest(unittest.TestCase):
+    """Unit tests for the "slack_helper" module."""
+
+    def test_normalize_channel_name(self):
+        self.assertEqual(slack_helper.normalize_channel_name(""), "")
+        self.assertEqual(slack_helper.normalize_channel_name('"isn\'t"'), "isnt")
+        self.assertEqual(slack_helper.normalize_channel_name("TEST"), "test")
+        self.assertEqual(slack_helper.normalize_channel_name("1  2--3__4"), "1-2-3-4")
+        self.assertEqual(slack_helper.normalize_channel_name("a `~!@#$%^&*() 1"), "a-1")
+        self.assertEqual(slack_helper.normalize_channel_name("b -_=+ []{}|\\ 2"), "b-2")
+        self.assertEqual(slack_helper.normalize_channel_name("c ;:'\" ,.<>/? 3"), "c-3")
+        self.assertEqual(slack_helper.normalize_channel_name("-foo "), "foo")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/purrr/users.py
+++ b/purrr/users.py
@@ -16,8 +16,9 @@ def github_username_to_slack_user_id(github_username: str) -> str:
 
     This function tries to match the email address first, and then
     falls back to matching the user's full name (case-insensitive).
-    This function also caches successful results for a day, to
-    reduce the amount of API calls, especially to Slack.
+
+    This function also caches both successful and failed results for
+    a day, to reduce the amount of API calls, especially to Slack.
 
     Args:
         github_username: GitHub username.
@@ -27,9 +28,9 @@ def github_username_to_slack_user_id(github_username: str) -> str:
     """
     # Optimization: if we already have it cached, no need to look it up.
     slack_user_id = data_helper.cached_slack_user_id(github_username)
-    if slack_user_id:
-        if slack_user_id in ("bot", "not found"):
-            slack_user_id = ""
+    if slack_user_id in ("bot", "not found"):
+        return ""
+    elif slack_user_id:
         return slack_user_id
 
     user = github.get_user(github_username)

--- a/purrr/users.py
+++ b/purrr/users.py
@@ -1,0 +1,105 @@
+"""User-related helper functions across GitHub and Slack."""
+
+from slack_sdk.errors import SlackApiError
+
+import data_helper
+import github_helper
+import slack_helper
+
+
+github = github_helper.shared_client
+slack = slack_helper.shared_client
+
+
+def github_username_to_slack_user_id(github_username: str) -> str:
+    """Convert a GitHub username to a Slack user ID.
+
+    This function tries to match the email address first, and then
+    falls back to matching the user's full name (case-insensitive).
+    This function also caches successful results for a day, to
+    reduce the amount of API calls, especially to Slack.
+
+    Args:
+        github_username: GitHub username.
+
+    Returns:
+        Slack user ID, or "" if not found.
+    """
+    # Optimization: if we already have it cached, no need to look it up.
+    slack_user_id = data_helper.cached_slack_user_id(github_username)
+    if slack_user_id:
+        if slack_user_id in ("bot", "not found"):
+            slack_user_id = ""
+        return slack_user_id
+
+    user = github.get_user(github_username)
+    gh_user_link = f"<{user.html_url}|{github_username}>"
+
+    # Special case: GitHub bots can't have Slack identities.
+    if user.type == "Bot":
+        data_helper.cache_slack_user_id(github_username, "bot")
+        return ""
+
+    # Try to match by the email address first.
+    if not user.email:
+        slack_helper.debug(f"GitHub user {gh_user_link}: email address not found")
+    else:
+        slack_user_id = _email_to_slack_user_id(user.email)
+        if slack_user_id:
+            data_helper.cache_slack_user_id(github_username, slack_user_id)
+            return slack_user_id
+
+    # Otherwise, try to match by the user's full name.
+    github_name = (user.name or "").lower()
+    if not github_name:
+        slack_helper.debug(f"GitHub user {gh_user_link}: full name not found")
+        return ""
+
+    for user in _slack_users():
+        profile = user.get("profile", {})
+        slack_names = (
+            profile.get("real_name", "").lower(),
+            profile.get("real_name_normalized", "").lower(),
+        )
+        if github_name in slack_names:
+            data_helper.cache_slack_user_id(github_username, user.id)
+            return user.id
+
+    # Optimization: cache unsuccessful results too (i.e. external users).
+    data_helper.debug(f"GitHub user {gh_user_link}: email & name not found in Slack")
+    data_helper.cache_slack_user_id(github_username, "not found")
+    return ""
+
+
+def _email_to_slack_user_id(email: str) -> str:
+    """Convert an email address to a Slack user ID.
+
+    Args:
+        email: Email address.
+
+    Returns:
+        Slack user ID, or "" if not found.
+    """
+    try:
+        resp = slack.users_lookupByEmail(email=email)
+        return resp.get("user", {}).get("id", "")
+    except SlackApiError as e:
+        error = f"Failed to look-up Slack user by email {email}"
+        data_helper.debug(f"{error}: `{e.response['error']}`")
+        return ""
+
+
+def _slack_users() -> list:
+    """Return a list of all Slack users in the workspace."""
+    users = []
+    next_cursor = None
+    while next_cursor != "":
+        try:
+            resp = slack.users_list(cursor=next_cursor, limit=100)
+            users += resp.get("members", [])
+            next_cursor = resp.get("response_metadata", {}).get("next_cursor", "")
+        except SlackApiError as e:
+            slack_helper.debug(f"Failed to list Slack users: `{e.response['error']}`")
+            next_cursor = ""
+
+    return users


### PR DESCRIPTION
This is a reasonable breakpoint in the migration from Starlark to Python: 1000 LoC is already a lot, and continuation is blocked by recent Python runtime issues.

Key things to review:
- Creating a new Slack channel when creating/reopening/undrafting a PR
- Slash commands: help, opt in/out
- "Infrastructure" in `slash_helper.py` and `users.py`
- A few new unit tests (might cover more functions in `slack_helper.py` with mocks)

FYI:
- New long-running workflow while for each active PR - to experiment with the viability of handling events and state there instead of asynchronously with Redis
- Preparing to migrate irreplaceable Redis functionalities with Google Sheets (not implemented yet, hopefully won't need to do a lot)

Refs: INT-65