### PR TITLE
ci: refresh settings and workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,9 @@ jobs:
 
       - name: Test with pytest
         run: pytest -v --ignore=purrr .
+
+      - name: Verify README.md is up to date
+        run: |
+          # If this check fails, run the Python script manually, and add README.md to this PR
+          python update_projects_table.py
+          git diff --exit-code README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,6 @@ jobs:
 
       - name: Verify README.md is up to date
         run: |
-          # If this check fails, run the Python script manually, and add README.md to this PR
+          # If this check fails, run "python update_projects_table.py", and add "README.md" to this PR.
           python update_projects_table.py
-          git diff --exit-code README.md
+          git diff --name-only --exit-code README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,3 @@
-# Continuous Integration workflow. For more information see:
 # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 # https://docs.astral.sh/ruff/integrations/#github-actions
 
@@ -17,16 +16,18 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: pip
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+
       - name: Lint & format with ruff
         run: |
           ruff check --output-format github .
           ruff format --check .
-      # (Enable this step once we have unit tests)
-      # - name: Test with pytest
-      #   run: pytest -v
+
+      - name: Test with pytest
+        run: pytest -v --ignore=purrr .

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-# Add "test" once we have unit tests
-all: deps format lint # test
+all: deps lint format test
 
 deps:
+	python -m pip install --upgrade pip
 	python -m pip install -r requirements.txt
 
 format: deps
@@ -11,6 +11,6 @@ lint: deps
 	ruff check --fix --output-format full .
 
 test: deps
-	pytest -v
+	pytest -v --ignore=purrr .
 
 .PHONY: all deps format lint test

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ demonstrate basic system features, integration APIs, and best practices.
 | [Slack notify on Confluence page created](./confluence_to_slack/) | When Confluence page is created the user will be notified on Slack | confluence, slack |
 | [Parse a file in S3 and insert to database](./data_pipeline/) | Triggered by a new GPX file on an S3 bucket, the pipeline code will parse the GPX file and insert it into a database. | aws, http, sqlite3 |
 | [Github Actions](./github_actions/) | GitHub workflows that interact across multiple repositories | github |
-| [Unregister non active users from Copilot](./github_copilot_seats/) | If Copilot was not used in a preceding period by users, the workflow automatically unregisters and notifies them. Users can ask for their subscription to be reinstated. | githubcopilot, slack |
+| [Cancel GitHub Copilot access for inactive users](./github_copilot_seats/) | If Copilot was not used in a preceding period by users, unsubscribe and notify them in Slack. Users can ask for their subscription to be reinstated. | githubcopilot, slack |
 | [Google Calendar To Asana](./google_cal_to_asana/) | Creates Asana tasks based on Google Calendar events | calendar, asana |
 | [Create Jira ticket from Google form](./google_forms_to_jira/) | Trigger by HTTP request, continue polling Google forms, and create Jira ticket based on the form's data | forms, http, jira |
 | [Hacker News Alerts in Slack ](./hackernews/) | Track Hacker News articles by topic and send updates to Slack | slack |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.ruff]
+src = ["./**"]
+target-version = "py312"
+
+[tool.ruff.lint]
+# https://docs.astral.sh/ruff/rules/
+extend-select = ["B", "C4", "D101", "D2", "D3", "DTZ", "E5", "I", "N", "PTH", "Q", "S", "UP", "W"]
+ignore = ["D213", "S113", "S311", "S314", "S4"]
+# TODO: BLE, D100, S113
+# MAYBE: D4, ANN, S314, FBT, CPY, TRY
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+lines-after-imports = 2
+order-by-type = false
+known-third-party = ["discord", "github"]
+
+force-single-line = true
+single-line-exclusions = ["autokitteh.atlassian", "autokitteh.google", "datetime", "typing"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pytest ~= 8.2
-ruff ~= 0.5
+pytest
+ruff


### PR DESCRIPTION
- Enable unit testing (except in the Purrr project - those UT require AK context)
- Add various optional but important linters to Ruff
- Don't pin pytest and ruff versions, no point in updating it from time to time like in the AK repo