### PR TITLE
fix: typing strictness

### DIFF
--- a/auth0_to_hubspot/program.py
+++ b/auth0_to_hubspot/program.py
@@ -1,6 +1,6 @@
 """This program adds new Auth0 users to HubSpot as contacts."""
 
-from datetime import datetime, UTC
+from datetime import datetime, timedelta, UTC
 import os
 
 from autokitteh.auth0 import auth0_client
@@ -8,7 +8,7 @@ from autokitteh.hubspot import hubspot_client
 from hubspot.crm.contacts import SimplePublicObjectInput
 
 
-LOOKUP_HOURS = int(os.getenv("HOURS"))
+LOOKUP_HOURS = int(os.getenv("HOURS") or "24")
 
 auth0 = auth0_client("auth0_conn")
 hubspot = hubspot_client("hubspot_conn")
@@ -29,7 +29,7 @@ def check_for_new_users(event):
 def _get_time_range(hours):
     """Calculate start and end times for user lookup."""
     now = datetime.now(UTC)
-    start_time = now - datetime.timedelta(hours=hours)
+    start_time = now - timedelta(hours=hours)
     return (start_time.isoformat() + "Z", now.isoformat() + "Z")
 
 

--- a/aws_health_to_slack/program.py
+++ b/aws_health_to_slack/program.py
@@ -58,7 +58,8 @@ def _aws_health_events() -> list[dict]:
     https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/health/client/describe_events_for_organization.html
     """
     try:
-        mins = int((os.getenv("TRIGGER_INTERVAL") or "1m")[:-1]) # Remove unit suffix and parse as int
+        # Remove the unit suffix ("m") and parse as an integer.
+        mins = int((os.getenv("TRIGGER_INTERVAL") or "1m")[:-1])
         prev_check = datetime.now(UTC) - timedelta(minutes=mins)
         filter = {"lastUpdatedTimes": [{"from": prev_check}]}
 

--- a/aws_health_to_slack/program.py
+++ b/aws_health_to_slack/program.py
@@ -58,7 +58,7 @@ def _aws_health_events() -> list[dict]:
     https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/health/client/describe_events_for_organization.html
     """
     try:
-        mins = int((os.getenv("TRIGGER_INTERVAL") or "1m")[:-1])
+        mins = int((os.getenv("TRIGGER_INTERVAL") or "1m")[:-1]) # Remove unit suffix and parse as int
         prev_check = datetime.now(UTC) - timedelta(minutes=mins)
         filter = {"lastUpdatedTimes": [{"from": prev_check}]}
 

--- a/data_pipeline/pipeline.py
+++ b/data_pipeline/pipeline.py
@@ -65,13 +65,17 @@ trkpt_tag = "{http://www.topografix.com/GPX/1/1}trkpt"
 def parse_gpx(track_id, data):
     io = BytesIO(data)
     root = Xml.parse(io).getroot()
-    return [
-        {
-            "track_id": track_id,
-            "n": i,
-            "lat": float(elem.get("lat")),
-            "lng": float(elem.get("lon")),
-            "height": float(elem.findtext(".//")),
-        }
-        for i, elem in enumerate(root.findall(".//" + trkpt_tag))
-    ]
+    records = []
+
+    for i, elem in enumerate(root.findall(".//" + trkpt_tag)):
+        records.append(
+            {
+                "track_id": track_id,
+                "n": i,
+                "lat": float(elem.get("lat", "0")),
+                "lng": float(elem.get("lon", "0")),
+                "height": float(elem.findtext(".//") or "0"),
+            }
+        )
+
+    return records

--- a/hackernews/program.py
+++ b/hackernews/program.py
@@ -9,7 +9,7 @@ import requests
 
 
 API_URL = "http://hn.algolia.com/api/v1/search_by_date?tags=story&page=0&query="
-POLLING_INTERVAL_SECS = int(os.getenv("POLLING_INTERVAL_SECS"))
+POLLING_INTERVAL_SECS = int(os.getenv("POLLING_INTERVAL_SECS") or "120")
 
 slack = slack_client("slack_connection")
 

--- a/purrr/github_helper.py
+++ b/purrr/github_helper.py
@@ -5,6 +5,6 @@ import os
 from autokitteh.github import github_client
 
 
-ORG_NAME = os.getenv("github_conn__target_name")
+ORG_NAME = os.getenv("github_conn__target_name") or ""
 
 shared_client = github_client("github_conn")

--- a/purrr/slack_channel.py
+++ b/purrr/slack_channel.py
@@ -128,9 +128,9 @@ def add_users(channel_id: str, github_users: list[str]) -> None:
     if len(slack_users) > 1000:
         slack_users = slack_users[:1000]
 
-    users = ",".join(slack_users)
+    user_ids = ",".join(slack_users)
     try:
-        slack.conversations_invite(channel=channel_id, users=users, force=True)
+        slack.conversations_invite(channel=channel_id, users=user_ids, force=True)
     except SlackApiError as e:
         if e.response["error"] == "already_in_channel":
             return

--- a/room_reservation/reserve_room.py
+++ b/room_reservation/reserve_room.py
@@ -32,7 +32,7 @@ def on_slack_slash_command(event):
         slack.chat_postMessage(channel=channel_id, text=err)
         return
 
-    user = slack.users_profile_get(user=data.user_id).get("profile")
+    user = slack.users_profile_get(user=data.user_id).get("profile", {})
 
     now = datetime.now(UTC)
     in_5_minutes = now + timedelta(minutes=5)


### PR DESCRIPTION
A few random fixes for type-related warnings from Pylance in VS Code, when type checking mode is "standard" instead of the default "off". Not specific to any project or task, and not a complete fix of the repo, just a few low-hanging fruits.

Most common: `str | None` --> `str` in places where it's clear that `None` is not expected.

```
os.getenv("var name") --> os.getenv("var name") or "default value"

dict.get("key") --> dict.get("key", "default value")
```

Also a few import tweaks to fix false-positive type warnings.