### PR TITLE
test(purrr): enable unit tests without AK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           ruff format --check .
 
       - name: Test with pytest
-        run: AUTOKITTEH_UNIT_TEST=1 pytest -v .
+        run: pytest -v .
 
       - name: Verify README.md is up to date
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           ruff format --check .
 
       - name: Test with pytest
-        run: pytest -v .
+        run: AUTOKITTEH_UNIT_TEST=1 pytest -v .
 
       - name: Verify README.md is up to date
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           ruff format --check .
 
       - name: Test with pytest
-        run: pytest -v --ignore=purrr .
+        run: pytest -v .
 
       - name: Verify README.md is up to date
         run: |

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,6 @@ lint: deps
 	ruff check --fix --output-format full .
 
 test: deps
-	AUTOKITTEH_UNIT_TEST=1 pytest -v .
+	pytest -v .
 
 .PHONY: all deps format lint test

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,6 @@ lint: deps
 	ruff check --fix --output-format full .
 
 test: deps
-	pytest -v --ignore=purrr .
+	pytest -v .
 
 .PHONY: all deps format lint test

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,6 @@ lint: deps
 	ruff check --fix --output-format full .
 
 test: deps
-	pytest -v .
+	AUTOKITTEH_UNIT_TEST=1 pytest -v .
 
 .PHONY: all deps format lint test

--- a/purrr/markdown_test.py
+++ b/purrr/markdown_test.py
@@ -4,8 +4,17 @@ import collections
 import unittest
 from unittest import mock
 
-import markdown
-import users
+from autokitteh import github, slack
+
+
+# This is needed before calling "import markdown" to avoid "ConnectionInitError"
+# when initializing these clients in Purrr modules, due to the lack of AutoKitteh
+# environment variables. This is also the reason for the "noqa" comments below.
+github.github_client = mock.MagicMock()
+slack.slack_client = mock.MagicMock()
+
+import markdown  # noqa: E402
+import users  # noqa: E402
 
 
 class MarkdownGithubToSlackTest(unittest.TestCase):

--- a/purrr/slack_cmd.py
+++ b/purrr/slack_cmd.py
@@ -36,6 +36,7 @@ def on_slack_slash_command(event):
 
     if args[0] in _COMMANDS:
         _COMMANDS[args[0]].handler(data, args)
+        return
 
     error = f"Error: unrecognized Purrr command: `{args[0]}`"
     slack.chat_postEphemeral(channel=data.channel_id, user=data.user_id, text=error)

--- a/purrr/slack_cmd_test.py
+++ b/purrr/slack_cmd_test.py
@@ -5,6 +5,7 @@ import unittest
 from unittest import mock
 
 import autokitteh
+from slack_sdk.web.client import WebClient
 
 import slack_cmd
 
@@ -16,7 +17,7 @@ fake_data = {
 }
 
 
-@mock.patch.object(slack_cmd, "slack", autospec=True)
+@mock.patch.object(slack_cmd, "slack", spec=WebClient)
 @mock.patch.object(slack_cmd, "data_helper", autospec=True)
 class SlackCmdTest(unittest.TestCase):
     """Unit tests for the "slack_cmd" module."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ order-by-type = false
 known-third-party = ["discord", "github"]
 
 force-single-line = true
-single-line-exclusions = ["autokitteh.atlassian", "autokitteh.google", "datetime", "typing"]
+single-line-exclusions = ["autokitteh", "autokitteh.atlassian", "autokitteh.google", "datetime", "typing"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 pytest
 ruff
+
+autokitteh
+PyGithub
+slack-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ pytest
 ruff
 
 autokitteh
+google-auth
 PyGithub
 slack-sdk


### PR DESCRIPTION
Improve mocking, and expect dummy GitHub and Slack clients instead of `ConnectionInitError` when the AutoKitteh Python SDK is running within unit tests.

~This PR depends on https://github.com/autokitteh/autokitteh/pull/964 being merged, and a new AutoKitteh Python SDK version released in PyPI - which is why unit tests are currently failing.~

Also found and fixed a small bug in `slack_cmd.py`

Refs: INT-159