### PR TITLE
test: convert all unit tests to Pytest

### DIFF
--- a/purrr/markdown_test.py
+++ b/purrr/markdown_test.py
@@ -1,276 +1,292 @@
 """Unit tests for the "markdown" module."""
 
 import collections
-import unittest
-from unittest import mock
 
 from autokitteh import github, slack
+import pytest
 
 
-# This is needed before calling "import markdown" to avoid "ConnectionInitError"
-# when initializing these clients in Purrr modules, due to the lack of AutoKitteh
-# environment variables. This is also the reason for the "noqa" comments below.
-github.github_client = mock.MagicMock()
-slack.slack_client = mock.MagicMock()
-
-import markdown  # noqa: E402
-import users  # noqa: E402
+@pytest.fixture(autouse=True)
+def setup_mock_github_and_slack_clients(mocker):
+    mocker.patch.object(github, "github_client", autospec=True)
+    mocker.patch.object(slack, "slack_client", autospec=True)
 
 
-class MarkdownGithubToSlackTest(unittest.TestCase):
+class TestGithubToSlack:
     """Unit tests for the "github_to_slack" function."""
 
     def test_trivial(self):
-        self.assertEqual(markdown.github_to_slack("", ""), "")
+        import markdown
 
-    def test_headers(self):
-        self.assertEqual(
-            markdown.github_to_slack("# Title 1\n\nFoo\n\n## Subtitle 2\nBar", ""),
-            "*Title 1*\n\nFoo\n\n*Subtitle 2*\nBar",
-        )
+        assert markdown.github_to_slack("", "") == ""
 
-    def test_text_style(self):
-        self.assertEqual(markdown.github_to_slack("_italic_", ""), "_italic_")
-        self.assertEqual(markdown.github_to_slack("*italic*", ""), "_italic_")
-        self.assertEqual(markdown.github_to_slack("__bold__", ""), "*bold*")
-        self.assertEqual(markdown.github_to_slack("**bold**", ""), "*bold*")
-        self.assertEqual(markdown.github_to_slack("***both***", ""), "_*both*_")
-        self.assertEqual(
-            markdown.github_to_slack("**this _is_ nested**", ""), "*this _is_ nested*"
-        )
-        self.assertEqual(
-            markdown.github_to_slack("**this *is* nested**", ""), "*this _is_ nested*"
-        )
-        self.assertEqual(
-            markdown.github_to_slack("__this _is_ nested__", ""), "*this _is_ nested*"
-        )
-        self.assertEqual(
-            markdown.github_to_slack("_this **is** nested_", ""), "_this *is* nested_"
-        )
-        # TODO: self.assertEqual(
-        #     markdown.github_to_slack("*this **is** nested*", ""), "_this *is* nested_"
-        # )
-        self.assertEqual(
-            markdown.github_to_slack("~~strikethrough~~", ""), "~strikethrough~"
-        )
+    def test_basic_headers(self):
+        import markdown
 
-    def test_text_blocks(self):
-        # Quotes.
-        self.assertEqual(
-            markdown.github_to_slack("111\n>222\n> 333\n444", ""),
-            "111\n>222\n> 333\n444",
-        )
-        # Code.
-        self.assertEqual(markdown.github_to_slack("`inline`", ""), "`inline`")
-        self.assertEqual(
-            markdown.github_to_slack("```\nmulti\nline\n```", ""),
-            "```\nmulti\nline\n```",
-        )
+        assert markdown.github_to_slack("# H1", "") == "*H1*"
+        assert markdown.github_to_slack("## H2", "") == "*H2*"
+        assert markdown.github_to_slack("### H3", "") == "*H3*"
+
+    def test_multiple_headers(self):
+        import markdown
+
+        actual = markdown.github_to_slack("# Title 1\n\nFoo\n\n## Subtitle 2\nBar", "")
+        assert actual == "*Title 1*\n\nFoo\n\n*Subtitle 2*\nBar"
+
+    def test_basic_text_style(self):
+        import markdown
+
+        assert markdown.github_to_slack("_italic_", "") == "_italic_"
+        assert markdown.github_to_slack("*italic*", "") == "_italic_"
+        assert markdown.github_to_slack("__bold__", "") == "*bold*"
+        assert markdown.github_to_slack("**bold**", "") == "*bold*"
+        assert markdown.github_to_slack("~~strikethrough~~", "") == "~strikethrough~"
+
+    def test_advanced_text_style(self):
+        import markdown
+
+        assert markdown.github_to_slack("***both***", "") == "_*both*_"
+        actual = markdown.github_to_slack("**this _is_ nested**", "")
+        assert actual == "*this _is_ nested*"
+        actual = markdown.github_to_slack("**this *is* nested**", "")
+        assert actual == "*this _is_ nested*"
+        actual = markdown.github_to_slack("__this _is_ nested__", "")
+        assert actual == "*this _is_ nested*"
+        actual = markdown.github_to_slack("_this **is** nested_", "")
+        assert actual == "_this *is* nested_"
+        # TODO:
+        # actual = markdown.github_to_slack("*this **is** nested*", "")
+        # assert actual == "_this *is* nested_"
+
+    def test_quote_blocks(self):
+        import markdown
+
+        actual = markdown.github_to_slack("111\n>222\n> 333\n444", "")
+        assert actual == "111\n>222\n> 333\n444"
+
+    def test_code_blocks(self):
+        import markdown
+
+        assert markdown.github_to_slack("`inline`", "") == "`inline`"
+        actual = markdown.github_to_slack("```\nmulti\nline\n```", "")
+        assert actual == "```\nmulti\nline\n```"
 
     def test_links(self):
-        self.assertEqual(markdown.github_to_slack("[text](url)", ""), "<url|text>")
-        self.assertEqual(
-            markdown.github_to_slack("!<url maybe with text>", ""),
-            "Image: <url maybe with text>",
-        )
+        import markdown
+
+        assert markdown.github_to_slack("[text](url)", "") == "<url|text>"
+        actual = markdown.github_to_slack("!<url maybe with text>", "")
+        assert actual == "Image: <url maybe with text>"
 
     def test_simple_lists(self):
-        self.assertEqual(
-            markdown.github_to_slack("- 111\n- 222\n- 333", ""),
-            "  •  111\n  •  222\n  •  333",
-        )
-        # TODO: self.assertEqual(
-        #     markdown.github_to_slack("* 111\n* 222\n* 333", ""),
-        #     "  •  111\n  •  222\n  •  333",
-        # )
-        self.assertEqual(
-            markdown.github_to_slack("+ 111\n+ 222\n+ 333", ""),
-            "  •  111\n  •  222\n  •  333",
-        )
+        import markdown
+
+        expected = "  •  111\n  •  222\n  •  333"
+        assert markdown.github_to_slack("- 111\n- 222\n- 333", "") == expected
+        assert markdown.github_to_slack("+ 111\n+ 222\n+ 333", "") == expected
+        # TODO: assert markdown.github_to_slack("* 111\n* 222\n* 333", "") == expected
 
     def test_nested_lists(self):
-        self.assertEqual(
-            markdown.github_to_slack("- 111\n  - 222\n  - 333\n- 444", ""),
-            "  •  111\n          ◦   222\n          ◦   333\n  •  444",
-        )
-        # TODO: self.assertEqual(
-        #     markdown.github_to_slack("* 111\n  * 222\n  * 333\n* 444", ""),
-        #     "  •  111\n          ◦   222\n          ◦   333\n  •  444",
-        # )
-        self.assertEqual(
-            markdown.github_to_slack("+ 111\n  + 222\n  + 333\n+ 444", ""),
-            "  •  111\n          ◦   222\n          ◦   333\n  •  444",
-        )
+        import markdown
 
-    @mock.patch.object(users, "github_username_to_slack_user_id", autospec=True)
-    def test_user_mentions(self, mock_func):
-        mock_func.side_effect = ["U123", None, None]
+        expect = "  •  111\n          ◦   222\n          ◦   333\n  •  444"
+        assert markdown.github_to_slack("- 111\n  - 222\n  - 333\n- 444", "") == expect
+        assert markdown.github_to_slack("+ 111\n  + 222\n  + 333\n+ 444", "") == expect
+        # TODO:
+        # assert markdown.github_to_slack("* 111\n  * 222\n  * 333\n* 444", "") == expec
+
+    def test_user_mentions(self, mocker):
+        import markdown
+        import users
+
+        pr = "https://github.com/org/repo/pull/123"
+        id = mocker.patch.object(
+            users, "github_username_to_slack_user_id", autospec=True
+        )
+        id.side_effect = ["U123", None, None]
 
         # Slack user found.
-        self.assertEqual(
-            markdown.github_to_slack("@user", "https://github.com/org/repo/pull/123"),
-            "<@U123>",
-        )
+        assert markdown.github_to_slack("@user", pr) == "<@U123>"
         # Slack user not found.
-        self.assertEqual(
-            markdown.github_to_slack("@user", "https://github.com/org/repo/pull/123"),
-            "<https://github.com/user|@user>",
-        )
+        actual = markdown.github_to_slack("@user", pr)
+        assert actual == "<https://github.com/user|@user>"
         # Team not found.
-        self.assertEqual(
-            markdown.github_to_slack(
-                "@org/team", "https://github.com/org/repo/pull/123"
-            ),
-            "<https://github.com/org/teams/team|@org/team>",
-        )
+        actual = markdown.github_to_slack("@org/team", pr)
+        assert actual == "<https://github.com/org/teams/team|@org/team>"
 
     def test_pr_references(self):
-        self.assertEqual(
-            markdown.github_to_slack("#123", "https://github.com/org/repo/pull/987"),
-            "<https://github.com/org/repo/pull/123|#123>",
-        )
+        import markdown
+
+        pr = "https://github.com/org/repo/pull/987"
+        actual = markdown.github_to_slack("#123", pr)
+        assert actual == "<https://github.com/org/repo/pull/123|#123>"
 
     def test_html_comments(self):
-        self.assertEqual(
-            markdown.github_to_slack("Blah\n<!-- hidden -->\nBlah blah", ""),
-            "Blah\n\nBlah blah",
-        )
+        import markdown
+
+        actual = markdown.github_to_slack("Blah\n<!-- hidden -->\nBlah blah", "")
+        assert actual == "Blah\n\nBlah blah"
 
 
-class MarkdownSlackToGithubTest(unittest.TestCase):
+class TestSlackToGithub:
     """Unit tests for the "slack_to_github" function."""
 
     def test_trivial(self):
-        self.assertEqual(markdown.slack_to_github(""), "")
+        import markdown
+
+        assert markdown.slack_to_github("") == ""
 
     def test_text_style(self):
-        self.assertEqual(markdown.slack_to_github("_italic_"), "_italic_")
-        self.assertEqual(markdown.slack_to_github("*bold*"), "**bold**")
-        self.assertEqual(markdown.slack_to_github("_*both*_"), "***both***")
-        self.assertEqual(
-            markdown.slack_to_github("~strikethrough~"), "~~strikethrough~~"
-        )
+        import markdown
+
+        assert markdown.slack_to_github("_italic_") == "_italic_"
+        assert markdown.slack_to_github("*bold*") == "**bold**"
+        assert markdown.slack_to_github("_*both*_") == "***both***"
+        assert markdown.slack_to_github("~strikethrough~") == "~~strikethrough~~"
 
         # Not needed, but good to have just in case someone
         # sends a non-Slack-markdown message programmatically:
-        self.assertEqual(markdown.slack_to_github("__italic__"), "_italic_")
-        self.assertEqual(markdown.slack_to_github("**bold**"), "**bold**")
-        self.assertEqual(markdown.slack_to_github("*_both_*"), "***both***")
-        self.assertEqual(markdown.slack_to_github("***both***"), "***both***")
-        self.assertEqual(
-            markdown.slack_to_github("~~strikethrough~~"), "~~strikethrough~~"
-        )
+        assert markdown.slack_to_github("__italic__") == "_italic_"
+        assert markdown.slack_to_github("**bold**") == "**bold**"
+        assert markdown.slack_to_github("*_both_*") == "***both***"
+        assert markdown.slack_to_github("***both***") == "***both***"
+        assert markdown.slack_to_github("~~strikethrough~~") == "~~strikethrough~~"
 
-    def test_text_blocks(self):
-        # Quotes.
-        self.assertEqual(
-            markdown.slack_to_github("111\n&gt;222\n&gt; 333\n444"),
-            "111\n>222\n> 333\n444",
-        )
-        self.assertEqual(
-            markdown.slack_to_github("111\n>222\n> 333\n444"),
-            "111\n>222\n> 333\n444",
-        )
-        # Code.
-        self.assertEqual(markdown.slack_to_github("`inline`"), "`inline`")
-        self.assertEqual(
-            markdown.slack_to_github("```multi\nline```"), "```\nmulti\nline\n```"
-        )
+    def test_quote_blocks(self):
+        import markdown
+
+        actual = markdown.slack_to_github("111\n&gt;222\n&gt; 333\n444")
+        assert actual == "111\n>222\n> 333\n444"
+        actual = markdown.slack_to_github("111\n>222\n> 333\n444")
+        assert actual == "111\n>222\n> 333\n444"
+
+    def test_code_blocks(self):
+        import markdown
+
+        assert markdown.slack_to_github("`inline`") == "`inline`"
+        assert markdown.slack_to_github("```multi\nline```") == "```\nmulti\nline\n```"
 
     def test_lists(self):
-        self.assertEqual(markdown.slack_to_github("• X\n• Y\n• Z"), "- X\n- Y\n- Z")
-        self.assertEqual(
-            markdown.slack_to_github(
-                "• X\n    ◦ Y\n        ▪︎ Z\n            • A\n                ◦ B"
-            ),
-            "- X\n  - Y\n    - Z\n      - A\n        - B",
+        import markdown
+
+        assert markdown.slack_to_github("• X\n• Y\n• Z") == "- X\n- Y\n- Z"
+        actual = markdown.slack_to_github(
+            "• X\n    ◦ Y\n        ▪︎ Z\n            • A\n                ◦ B"
         )
+        assert actual == "- X\n  - Y\n    - Z\n      - A\n        - B"
 
     def test_links(self):
-        self.assertEqual(markdown.slack_to_github("<url|text>"), "[text](url)")
-        self.assertEqual(markdown.slack_to_github("<url|>"), "[](url)")
-        self.assertEqual(markdown.slack_to_github("<url>"), "<url>")
+        import markdown
 
-    @mock.patch.object(markdown, "_slack_team_id", autospec=True)
-    @mock.patch.object(markdown, "_slack_channel_name", autospec=True)
-    def test_channel(self, mock_channel_name, mock_team_id):
-        mock_channel_name.return_value = "channel"
-        mock_team_id.return_value = "TEAM_ID"
+        assert markdown.slack_to_github("<url|text>") == "[text](url)"
+        assert markdown.slack_to_github("<url|>"), "[](url)"
+        assert markdown.slack_to_github("<url>"), "<url>"
 
-        self.assertEqual(
-            markdown.slack_to_github("<#C123>"),
-            "[#channel](slack://channel?team=TEAM_ID&id=C123)",
-        )
-        self.assertEqual(
-            markdown.slack_to_github("<#C123|>"),
-            "[#channel](slack://channel?team=TEAM_ID&id=C123)",
-        )
-        self.assertEqual(
-            markdown.slack_to_github("<#C123|custom-name>"),
-            "[#custom-name](slack://channel?team=TEAM_ID&id=C123)",
-        )
+    def test_channel(self, mocker):
+        import markdown
+
+        channel = mocker.patch.object(markdown, "_slack_channel_name", autospec=True)
+        channel.return_value = "CHANNEL_NAME"
+        team = mocker.patch.object(markdown, "_slack_team_id", autospec=True)
+        team.return_value = "TEAM_ID"
+
+        expected = "[#CHANNEL_NAME](slack://channel?team=TEAM_ID&id=C123)"
+        assert markdown.slack_to_github("<#C123>") == expected
+        assert markdown.slack_to_github("<#C123|>") == expected
+
+        actual = markdown.slack_to_github("<#C123|custom-name>")
+        assert actual == "[#custom-name](slack://channel?team=TEAM_ID&id=C123)"
 
 
 FakeGithubUser = collections.namedtuple("FakeGithubUser", ["name", "login"])
 
 
-@mock.patch.object(users, "_slack_user_info", autospec=True)
-@mock.patch.object(users, "_github_users", autospec=True)
-@mock.patch.object(users, "_email_to_github_user_id", autospec=True)
-class MarkdownSlackToGithubUserMentionsTest(unittest.TestCase):
+class TestSlackToGithubUserMentions:
     """Unit tests for user mentions in the "slack_to_github" function."""
 
-    def test_slack_user_info_error(self, mock_email, mock_github, mock_slack):
-        mock_slack.return_value = {}
-        self.assertEqual(markdown.slack_to_github("<@U123>"), "Someone")
+    @pytest.fixture
+    def mock_github_user_id(self, mocker):
+        import users
 
-    def test_email_and_name_not_found_in_slack_profile(
-        self, mock_email, mock_github, mock_slack
-    ):
-        mock_slack.return_value = {"profile": {"foo": "bar"}}
-        self.assertEqual(markdown.slack_to_github("<@U123>"), "Someone")
+        return mocker.patch.object(users, "_email_to_github_user_id", autospec=True)
 
-    def test_named_and_unnamed_slack_apps(self, mock_email, mock_github, mock_slack):
-        mock_slack.side_effect = [
+    @pytest.fixture
+    def mock_github_users(self, mocker):
+        import users
+
+        return mocker.patch.object(users, "_github_users", autospec=True)
+
+    @pytest.fixture
+    def mock_slack_user_info(self, mocker):
+        import users
+
+        return mocker.patch.object(users, "_slack_user_info", autospec=True)
+
+    def test_slack_user_info_error(self, mock_slack_user_info):
+        import markdown
+
+        mock_slack_user_info.return_value = {}
+        assert markdown.slack_to_github("<@U123>") == "Someone"
+
+    def test_email_and_name_not_found_in_slack_profile(self, mock_slack_user_info):
+        import markdown
+
+        mock_slack_user_info.return_value = {"profile": {"foo": "bar"}}
+        assert markdown.slack_to_github("<@U123>") == "Someone"
+
+    def test_named_and_unnamed_slack_apps(self, mock_slack_user_info):
+        import markdown
+
+        mock_slack_user_info.side_effect = [
             {"is_bot": True, "profile": {"real_name": "Mr. Robot"}},
             {"is_bot": True},
         ]
-        self.assertEqual(markdown.slack_to_github("<@U123>"), "Mr. Robot")
-        self.assertEqual(markdown.slack_to_github("<@U123>"), "Some Slack app")
+        assert markdown.slack_to_github("<@U123>") == "Mr. Robot"
+        assert markdown.slack_to_github("<@U123>") == "Some Slack app"
 
-    def test_match_by_email(self, mock_email, mock_github, mock_slack):
-        mock_slack.return_value = {"profile": {"email": "me@test.com"}}
-        mock_email.return_value = "username"
-        self.assertEqual(markdown.slack_to_github("<@U123>"), "@username")
+    def test_match_by_email(self, mock_github_user_id, mock_slack_user_info):
+        import markdown
 
-    def test_match_by_name(self, mock_email, mock_github, mock_slack):
-        mock_slack.return_value = {
+        mock_github_user_id.return_value = "username"
+        mock_slack_user_info.return_value = {"profile": {"email": "me@test.com"}}
+        assert markdown.slack_to_github("<@U123>") == "@username"
+
+    def test_match_by_name(
+        self, mock_github_user_id, mock_github_users, mock_slack_user_info
+    ):
+        import markdown
+
+        mock_github_user_id.return_value = ""
+        mock_github_users.return_value = [FakeGithubUser("John Doe", "username")]
+        mock_slack_user_info.return_value = {
             "profile": {"email": "me@test.com", "real_name": "John Doe"}
         }
-        mock_email.return_value = ""
-        mock_github.return_value = [FakeGithubUser("John Doe", "username")]
-        self.assertEqual(markdown.slack_to_github("<@U123>"), "@username")
+        assert markdown.slack_to_github("<@U123>") == "@username"
 
-    def test_no_matches_by_name(self, mock_email, mock_github, mock_slack):
-        mock_slack.return_value = {
+    def test_no_matches_by_name(
+        self, mock_github_user_id, mock_github_users, mock_slack_user_info
+    ):
+        import markdown
+
+        mock_github_user_id.return_value = ""
+        mock_github_users.return_value = []
+        mock_slack_user_info.return_value = {
             "profile": {"email": "me@test.com", "real_name": "John Doe"}
         }
-        mock_email.return_value = ""
-        mock_github.return_value = []
-        self.assertEqual(markdown.slack_to_github("<@U123>"), "John Doe")
+        assert markdown.slack_to_github("<@U123>") == "John Doe"
 
-    def test_too_many_matches_by_name(self, mock_email, mock_github, mock_slack):
-        mock_slack.return_value = {
-            "profile": {"email": "me@test.com", "real_name": "John Doe"}
-        }
-        mock_email.return_value = ""
-        mock_github.return_value = [
+    def test_too_many_matches_by_name(
+        self, mock_github_user_id, mock_github_users, mock_slack_user_info
+    ):
+        import markdown
+
+        mock_github_user_id.return_value = ""
+        mock_github_users.return_value = [
             FakeGithubUser("John Doe", "username1"),
             FakeGithubUser("john doe", "username2"),
             FakeGithubUser("JOHN DOE", "username3"),
         ]
-        self.assertEqual(markdown.slack_to_github("<@U123>"), "John Doe")
-
-
-if __name__ == "__main__":
-    unittest.main()
+        mock_slack_user_info.return_value = {
+            "profile": {"email": "me@test.com", "real_name": "John Doe"}
+        }
+        assert markdown.slack_to_github("<@U123>") == "John Doe"

--- a/purrr/slack_cmd_test.py
+++ b/purrr/slack_cmd_test.py
@@ -27,8 +27,8 @@ class TestSlackCmd:
     @pytest.fixture
     def mock_data_helper(self, mocker):
         import slack_cmd
-        yield mocker.patch.object(slack_cmd, "data_helper", autospec=True)
-        return
+
+        return mocker.patch.object(slack_cmd, "data_helper", autospec=True)
 
     def test_help_text(self):
         import slack_cmd

--- a/purrr/slack_cmd_test.py
+++ b/purrr/slack_cmd_test.py
@@ -13,6 +13,13 @@ def setup_mock_github_and_slack_clients(mocker):
     mocker.patch.object(slack, "slack_client", autospec=True)
 
 
+@pytest.fixture
+def mock_data_helper(mocker):
+    import slack_cmd
+
+    return mocker.patch.object(slack_cmd, "data_helper", autospec=True)
+
+
 fake_data = {
     "channel_id": "purr-debug",
     "user_id": "user",
@@ -20,120 +27,114 @@ fake_data = {
 }
 
 
-# @mock.patch.object(slack_cmd, "data_helper", autospec=True)
-class TestSlackCmd:
-    """Unit tests for the "slack_cmd" module."""
+def test_help_text():
+    import slack_cmd
 
-    @pytest.fixture
-    def mock_data_helper(self, mocker):
-        import slack_cmd
+    data = autokitteh.AttrDict(fake_data)
+    text = slack_cmd._help_text(data)
 
-        return mocker.patch.object(slack_cmd, "data_helper", autospec=True)
+    for cmd in slack_cmd._COMMANDS.values():
+        assert cmd.label in text
+        assert cmd.description in text
 
-    def test_help_text(self):
-        import slack_cmd
 
-        data = autokitteh.AttrDict(fake_data)
-        text = slack_cmd._help_text(data)
+def test_on_slack_slash_command_without_text():
+    import slack_cmd
 
-        for cmd in slack_cmd._COMMANDS.values():
-            assert cmd.label in text
-            assert cmd.description in text
+    slack_cmd.slack.chat_postEphemeral.reset_mock()
 
-    def test_on_slack_slash_command_without_text(self):
-        import slack_cmd
+    event = autokitteh.AttrDict({"data": fake_data | {"text": ""}})
+    slack_cmd.on_slack_slash_command(event)
 
-        slack_cmd.slack.chat_postEphemeral.reset_mock()
+    slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
+        channel=event.data.channel_id,
+        user=event.data.user_id,
+        text=slack_cmd._help_text(event.data),
+    )
 
-        event = autokitteh.AttrDict({"data": fake_data | {"text": ""}})
-        slack_cmd.on_slack_slash_command(event)
 
-        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
-            channel=event.data.channel_id,
-            user=event.data.user_id,
-            text=slack_cmd._help_text(event.data),
-        )
+def test_on_slack_slash_command_with_help():
+    import slack_cmd
 
-    def test_on_slack_slash_command_with_help(self):
-        import slack_cmd
+    slack_cmd.slack.chat_postEphemeral.reset_mock()
 
-        slack_cmd.slack.chat_postEphemeral.reset_mock()
+    event = autokitteh.AttrDict({"data": fake_data | {"text": "help"}})
+    slack_cmd.on_slack_slash_command(event)
 
-        event = autokitteh.AttrDict({"data": fake_data | {"text": "help"}})
-        slack_cmd.on_slack_slash_command(event)
+    slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
+        channel=event.data.channel_id,
+        user=event.data.user_id,
+        text=slack_cmd._help_text(event.data),
+    )
 
-        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
-            channel=event.data.channel_id,
-            user=event.data.user_id,
-            text=slack_cmd._help_text(event.data),
-        )
 
-    def test_on_slack_slash_command_with_noop_opt_in(self, mock_data_helper):
-        import slack_cmd
+def test_on_slack_slash_command_with_noop_opt_in(mock_data_helper):
+    import slack_cmd
 
-        mock_data_helper.slack_opted_out.return_value = ""
-        slack_cmd.slack.chat_postEphemeral.reset_mock()
+    mock_data_helper.slack_opted_out.return_value = ""
+    slack_cmd.slack.chat_postEphemeral.reset_mock()
 
-        event = autokitteh.AttrDict({"data": fake_data | {"text": "opt-in"}})
-        slack_cmd.on_slack_slash_command(event)
+    event = autokitteh.AttrDict({"data": fake_data | {"text": "opt-in"}})
+    slack_cmd.on_slack_slash_command(event)
 
-        mock_data_helper.slack_opted_out.assert_called_once_with(event.data.user_id)
-        mock_data_helper.slack_opt_in.assert_not_called()
-        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
-            channel=event.data.channel_id,
-            user=event.data.user_id,
-            text=":bell: You're already opted into Purrr",
-        )
+    mock_data_helper.slack_opted_out.assert_called_once_with(event.data.user_id)
+    mock_data_helper.slack_opt_in.assert_not_called()
+    slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
+        channel=event.data.channel_id,
+        user=event.data.user_id,
+        text=":bell: You're already opted into Purrr",
+    )
 
-    def test_on_slack_slash_command_with_actual_opt_in(self, mock_data_helper):
-        import slack_cmd
 
-        mock_data_helper.slack_opted_out.return_value = datetime.min
-        slack_cmd.slack.chat_postEphemeral.reset_mock()
+def test_on_slack_slash_command_with_actual_opt_in(mock_data_helper):
+    import slack_cmd
 
-        event = autokitteh.AttrDict({"data": fake_data | {"text": "opt-in"}})
-        slack_cmd.on_slack_slash_command(event)
+    mock_data_helper.slack_opted_out.return_value = datetime.min
+    slack_cmd.slack.chat_postEphemeral.reset_mock()
 
-        mock_data_helper.slack_opted_out.assert_called_once_with(event.data.user_id)
-        mock_data_helper.slack_opt_in.assert_called_once_with(event.data.user_id)
-        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
-            channel=event.data.channel_id,
-            user=event.data.user_id,
-            text=":bell: You are now opted into Purrr",
-        )
+    event = autokitteh.AttrDict({"data": fake_data | {"text": "opt-in"}})
+    slack_cmd.on_slack_slash_command(event)
 
-    def test_on_slack_slash_command_with_noop_opt_out(self, mock_data_helper):
-        import slack_cmd
+    mock_data_helper.slack_opted_out.assert_called_once_with(event.data.user_id)
+    mock_data_helper.slack_opt_in.assert_called_once_with(event.data.user_id)
+    slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
+        channel=event.data.channel_id,
+        user=event.data.user_id,
+        text=":bell: You are now opted into Purrr",
+    )
 
-        mock_data_helper.slack_opted_out.return_value = datetime.min
-        slack_cmd.slack.chat_postEphemeral.reset_mock()
 
-        event = autokitteh.AttrDict({"data": fake_data | {"text": "opt-out"}})
-        slack_cmd.on_slack_slash_command(event)
+def test_on_slack_slash_command_with_noop_opt_out(mock_data_helper):
+    import slack_cmd
 
-        mock_data_helper.slack_opted_out.assert_called_once_with(event.data.user_id)
-        mock_data_helper.slack_opt_out.assert_not_called()
-        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
-            channel=event.data.channel_id,
-            user=event.data.user_id,
-            text=(
-                ":no_bell: You're already opted out of Purrr since: 0001-01-01 00:00:00"
-            ),
-        )
+    mock_data_helper.slack_opted_out.return_value = datetime.min
+    slack_cmd.slack.chat_postEphemeral.reset_mock()
 
-    def test_on_slack_slash_command_with_second_opt_out(self, mock_data_helper):
-        import slack_cmd
+    event = autokitteh.AttrDict({"data": fake_data | {"text": "opt-out"}})
+    slack_cmd.on_slack_slash_command(event)
 
-        mock_data_helper.slack_opted_out.return_value = ""
-        slack_cmd.slack.chat_postEphemeral.reset_mock()
+    mock_data_helper.slack_opted_out.assert_called_once_with(event.data.user_id)
+    mock_data_helper.slack_opt_out.assert_not_called()
+    slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
+        channel=event.data.channel_id,
+        user=event.data.user_id,
+        text=(":no_bell: You're already opted out of Purrr since: 0001-01-01 00:00:00"),
+    )
 
-        event = autokitteh.AttrDict({"data": fake_data | {"text": "opt-out"}})
-        slack_cmd.on_slack_slash_command(event)
 
-        mock_data_helper.slack_opted_out.assert_called_once_with(event.data.user_id)
-        mock_data_helper.slack_opt_out.assert_called_once_with(event.data.user_id)
-        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
-            channel=event.data.channel_id,
-            user=event.data.user_id,
-            text=":no_bell: You are now opted out of Purrr",
-        )
+def test_on_slack_slash_command_with_second_opt_out(mock_data_helper):
+    import slack_cmd
+
+    mock_data_helper.slack_opted_out.return_value = ""
+    slack_cmd.slack.chat_postEphemeral.reset_mock()
+
+    event = autokitteh.AttrDict({"data": fake_data | {"text": "opt-out"}})
+    slack_cmd.on_slack_slash_command(event)
+
+    mock_data_helper.slack_opted_out.assert_called_once_with(event.data.user_id)
+    mock_data_helper.slack_opt_out.assert_called_once_with(event.data.user_id)
+    slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
+        channel=event.data.channel_id,
+        user=event.data.user_id,
+        text=":no_bell: You are now opted out of Purrr",
+    )

--- a/purrr/slack_cmd_test.py
+++ b/purrr/slack_cmd_test.py
@@ -1,13 +1,16 @@
 """Unit tests for the "slack_cmd" module."""
 
 from datetime import datetime
-import unittest
-from unittest import mock
 
 import autokitteh
-from slack_sdk.web.client import WebClient
+from autokitteh import github, slack
+import pytest
 
-import slack_cmd
+
+@pytest.fixture(autouse=True)
+def setup_mock_github_and_slack_clients(mocker):
+    mocker.patch.object(github, "github_client", autospec=True)
+    mocker.patch.object(slack, "slack_client", autospec=True)
 
 
 fake_data = {
@@ -17,82 +20,100 @@ fake_data = {
 }
 
 
-@mock.patch.object(slack_cmd, "slack", spec=WebClient)
-@mock.patch.object(slack_cmd, "data_helper", autospec=True)
-class SlackCmdTest(unittest.TestCase):
+# @mock.patch.object(slack_cmd, "data_helper", autospec=True)
+class TestSlackCmd:
     """Unit tests for the "slack_cmd" module."""
 
-    def test_help_text(self, *_):
+    @pytest.fixture
+    def mock_data_helper(self, mocker):
+        import slack_cmd
+        yield mocker.patch.object(slack_cmd, "data_helper", autospec=True)
+        return
+
+    def test_help_text(self):
+        import slack_cmd
+
         data = autokitteh.AttrDict(fake_data)
         text = slack_cmd._help_text(data)
 
         for cmd in slack_cmd._COMMANDS.values():
-            self.assertIn(cmd.label, text)
-            self.assertIn(cmd.description, text)
+            assert cmd.label in text
+            assert cmd.description in text
 
-    def test_on_slack_slash_command_without_text(self, _, mock_slack):
+    def test_on_slack_slash_command_without_text(self):
+        import slack_cmd
+
+        slack_cmd.slack.chat_postEphemeral.reset_mock()
+
         event = autokitteh.AttrDict({"data": fake_data | {"text": ""}})
         slack_cmd.on_slack_slash_command(event)
 
-        mock_slack.chat_postEphemeral.assert_called_once_with(
+        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
             channel=event.data.channel_id,
             user=event.data.user_id,
             text=slack_cmd._help_text(event.data),
         )
 
-    def test_on_slack_slash_command_with_help(self, _, mock_slack):
+    def test_on_slack_slash_command_with_help(self):
+        import slack_cmd
+
+        slack_cmd.slack.chat_postEphemeral.reset_mock()
+
         event = autokitteh.AttrDict({"data": fake_data | {"text": "help"}})
         slack_cmd.on_slack_slash_command(event)
 
-        mock_slack.chat_postEphemeral.assert_called_once_with(
+        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
             channel=event.data.channel_id,
             user=event.data.user_id,
             text=slack_cmd._help_text(event.data),
         )
 
-    def test_on_slack_slash_command_with_noop_opt_in(
-        self, mock_data_helper, mock_slack
-    ):
+    def test_on_slack_slash_command_with_noop_opt_in(self, mock_data_helper):
+        import slack_cmd
+
         mock_data_helper.slack_opted_out.return_value = ""
+        slack_cmd.slack.chat_postEphemeral.reset_mock()
 
         event = autokitteh.AttrDict({"data": fake_data | {"text": "opt-in"}})
         slack_cmd.on_slack_slash_command(event)
 
         mock_data_helper.slack_opted_out.assert_called_once_with(event.data.user_id)
         mock_data_helper.slack_opt_in.assert_not_called()
-        mock_slack.chat_postEphemeral.assert_called_once_with(
+        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
             channel=event.data.channel_id,
             user=event.data.user_id,
             text=":bell: You're already opted into Purrr",
         )
 
-    def test_on_slack_slash_command_with_actual_opt_in(
-        self, mock_data_helper, mock_slack
-    ):
+    def test_on_slack_slash_command_with_actual_opt_in(self, mock_data_helper):
+        import slack_cmd
+
         mock_data_helper.slack_opted_out.return_value = datetime.min
+        slack_cmd.slack.chat_postEphemeral.reset_mock()
 
         event = autokitteh.AttrDict({"data": fake_data | {"text": "opt-in"}})
         slack_cmd.on_slack_slash_command(event)
 
         mock_data_helper.slack_opted_out.assert_called_once_with(event.data.user_id)
         mock_data_helper.slack_opt_in.assert_called_once_with(event.data.user_id)
-        mock_slack.chat_postEphemeral.assert_called_once_with(
+        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
             channel=event.data.channel_id,
             user=event.data.user_id,
             text=":bell: You are now opted into Purrr",
         )
 
-    def test_on_slack_slash_command_with_noop_opt_out(
-        self, mock_data_helper, mock_slack
-    ):
+    def test_on_slack_slash_command_with_noop_opt_out(self, mock_data_helper):
+        import slack_cmd
+
         mock_data_helper.slack_opted_out.return_value = datetime.min
+        slack_cmd.slack.chat_postEphemeral.reset_mock()
 
         event = autokitteh.AttrDict({"data": fake_data | {"text": "opt-out"}})
         slack_cmd.on_slack_slash_command(event)
 
         mock_data_helper.slack_opted_out.assert_called_once_with(event.data.user_id)
         mock_data_helper.slack_opt_out.assert_not_called()
-        mock_slack.chat_postEphemeral.assert_called_once_with(
+        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
             channel=event.data.channel_id,
             user=event.data.user_id,
             text=(
@@ -100,22 +121,19 @@ class SlackCmdTest(unittest.TestCase):
             ),
         )
 
-    def test_on_slack_slash_command_with_second_opt_out(
-        self, mock_data_helper, mock_slack
-    ):
+    def test_on_slack_slash_command_with_second_opt_out(self, mock_data_helper):
+        import slack_cmd
+
         mock_data_helper.slack_opted_out.return_value = ""
+        slack_cmd.slack.chat_postEphemeral.reset_mock()
 
         event = autokitteh.AttrDict({"data": fake_data | {"text": "opt-out"}})
         slack_cmd.on_slack_slash_command(event)
 
         mock_data_helper.slack_opted_out.assert_called_once_with(event.data.user_id)
         mock_data_helper.slack_opt_out.assert_called_once_with(event.data.user_id)
-        mock_slack.chat_postEphemeral.assert_called_once_with(
+        slack_cmd.slack.chat_postEphemeral.assert_called_once_with(
             channel=event.data.channel_id,
             user=event.data.user_id,
             text=":no_bell: You are now opted out of Purrr",
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/purrr/slack_helper_test.py
+++ b/purrr/slack_helper_test.py
@@ -1,23 +1,18 @@
 """Unit tests for the "slack_helper" module."""
 
-import unittest
-
-import slack_helper
+from autokitteh import github, slack
 
 
-class SlackHelperTest(unittest.TestCase):
-    """Unit tests for the "slack_helper" module."""
+def test_normalize_channel_name(mocker):
+    mocker.patch.object(github, "github_client", autospec=True)
+    mocker.patch.object(slack, "slack_client", autospec=True)
+    import slack_helper
 
-    def test_normalize_channel_name(self):
-        self.assertEqual(slack_helper.normalize_channel_name(""), "")
-        self.assertEqual(slack_helper.normalize_channel_name('"isn\'t"'), "isnt")
-        self.assertEqual(slack_helper.normalize_channel_name("TEST"), "test")
-        self.assertEqual(slack_helper.normalize_channel_name("1  2--3__4"), "1-2-3-4")
-        self.assertEqual(slack_helper.normalize_channel_name("a `~!@#$%^&*() 1"), "a-1")
-        self.assertEqual(slack_helper.normalize_channel_name("b -_=+ []{}|\\ 2"), "b-2")
-        self.assertEqual(slack_helper.normalize_channel_name("c ;:'\" ,.<>/? 3"), "c-3")
-        self.assertEqual(slack_helper.normalize_channel_name("-foo "), "foo")
-
-
-if __name__ == "__main__":
-    unittest.main()
+    assert slack_helper.normalize_channel_name("") == ""
+    assert slack_helper.normalize_channel_name('"isn\'t"') == "isnt"
+    assert slack_helper.normalize_channel_name("TEST") == "test"
+    assert slack_helper.normalize_channel_name("1  2--3__4") == "1-2-3-4"
+    assert slack_helper.normalize_channel_name("a `~!@#$%^&*() 1") == "a-1"
+    assert slack_helper.normalize_channel_name("b -_=+ []{}|\\ 2") == "b-2"
+    assert slack_helper.normalize_channel_name("c ;:'\" ,.<>/? 3") == "c-3"
+    assert slack_helper.normalize_channel_name("-foo ") == "foo"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ target-version = "py312"
 
 [tool.ruff.lint]
 # https://docs.astral.sh/ruff/rules/
-extend-select = ["B", "C4", "D101", "D2", "D3", "DTZ", "E5", "I", "N", "PTH", "Q", "S", "UP", "W"]
-ignore = ["D213", "S113", "S311", "S314", "S4"]
+extend-select = ["B", "C4", "D101", "D2", "D3", "DTZ", "E5", "I", "N", "PT", "PTH", "Q", "S", "UP", "W"]
+ignore = ["D213", "S101", "S113", "S311", "S314", "S4"]
 # TODO: BLE, D100, S113
 # MAYBE: D4, ANN, S314, FBT, CPY, TRY
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ target-version = "py312"
 # https://docs.astral.sh/ruff/rules/
 extend-select = ["B", "C4", "D101", "D2", "D3", "DTZ", "E5", "I", "N", "PT", "PTH", "Q", "S", "UP", "W"]
 ignore = ["D213", "S101", "S113", "S311", "S314", "S4"]
-# TODO: BLE, D100, S113
+# TODO(INT-178, INT-179, INT-180): BLE, D100, S113
 # MAYBE: D4, ANN, S314, FBT, CPY, TRY
 
 [tool.ruff.lint.isort]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-mock
 ruff
 
 autokitteh

--- a/update_projects_table_test.py
+++ b/update_projects_table_test.py
@@ -11,6 +11,7 @@ class TestExtractMetadata:
 
     @pytest.fixture
     def tmp_file(self, tmp_path):
+        """Thin wrapper over "tmp_path" to create and delete a temporary file."""
         fp = tmp_path / "tmp_file"
         yield fp
         fp.unlink()

--- a/update_projects_table_test.py
+++ b/update_projects_table_test.py
@@ -1,119 +1,132 @@
-from pathlib import Path
-import tempfile
-import unittest
+"""Unit tests for the "update_projects_table" module."""
 
+from pathlib import Path
+
+import pytest
 import update_projects_table
 
 
-class TestCreateProjectTable(unittest.TestCase):
-    """Unit tests for the "update_projects_table" module."""
+class TestExtractMetadata:
+    """Unit tests for the "extract_metadata" function."""
 
-    def generic_test_extract_metadata(self, input, expected):
-        actual = {}
-        with tempfile.NamedTemporaryFile(delete_on_close=False) as f:
-            if input:
-                f.write(input)
-            f.close()
-            actual = update_projects_table.extract_metadata(Path(f.name))
-        self.assertEqual(expected, actual)
+    @pytest.fixture
+    def tmp_file(self, tmp_path):
+        fp = tmp_path / "tmp_file"
+        yield fp
+        fp.unlink()
 
-    def test_extract_metadata(self):
-        # Empty metadata.
-        self.generic_test_extract_metadata(None, {})
+    def test_empty_metadata(self, tmp_file):
+        tmp_file.write_text("")
+        assert update_projects_table.extract_metadata(tmp_file) == {}
 
-        # Single basic field.
-        self.generic_test_extract_metadata(b"foo: bar", {"foo": "bar"})
+    def test_single_basic_field(self, tmp_file):
+        tmp_file.write_text("foo: bar")
+        assert update_projects_table.extract_metadata(tmp_file) == {"foo": "bar"}
 
-        # Single basic field with extra whitespaces (a recoverable typo).
-        self.generic_test_extract_metadata(b"foo:   bar\n\n\n", {"foo": "bar"})
+    def test_single_basic_field_with_extra_whitespaces(self, tmp_file):
+        tmp_file.write_text("foo:   bar\n\n\n")
+        assert update_projects_table.extract_metadata(tmp_file) == {"foo": "bar"}
 
-        # Multiple basic fields.
-        input = b"aaa: 111\nbbb: 222\nccc: 333\n"
+    def test_multiple_basic_fields(self, tmp_file):
+        tmp_file.write_text("aaa: 111\nbbb: 222\nccc: 333\n")
         expected = {"aaa": "111", "bbb": "222", "ccc": "333"}
-        self.generic_test_extract_metadata(input, expected)
+        assert update_projects_table.extract_metadata(tmp_file) == expected
 
-        # Empty integrations field.
-        self.generic_test_extract_metadata(b"integrations:", {})
-        self.generic_test_extract_metadata(b"integrations: ", {})
-        self.generic_test_extract_metadata(b"integrations: []", {"integrations": []})
+    def test_empty_integrations_field(self, tmp_file):
+        tmp_file.write_text("integrations:")
+        assert update_projects_table.extract_metadata(tmp_file) == {}
 
-        # Non-empty integrations field.
-        input = b'integrations: ["a"]'
+        tmp_file.write_text("integrations: ")
+        assert update_projects_table.extract_metadata(tmp_file) == {}
+
+        tmp_file.write_text("integrations: []")
+        assert update_projects_table.extract_metadata(tmp_file) == {"integrations": []}
+
+    def test_non_empty_integrations_field(self, tmp_file):
+        tmp_file.write_text('integrations: ["a"]')
         expected = {"integrations": ["a"]}
-        self.generic_test_extract_metadata(input, expected)
+        assert update_projects_table.extract_metadata(tmp_file) == expected
 
-        input = b'integrations: ["a",]'
+        tmp_file.write_text('integrations: ["a",]')
         expected = {"integrations": ["a"]}
-        self.generic_test_extract_metadata(input, expected)
+        assert update_projects_table.extract_metadata(tmp_file) == expected
 
-        input = b'integrations: ["a","b"]'
+        tmp_file.write_text('integrations: ["a","b"]')
         expected = {"integrations": ["a", "b"]}
-        self.generic_test_extract_metadata(input, expected)
+        assert update_projects_table.extract_metadata(tmp_file) == expected
 
-        input = b'integrations: ["a", "b"]'
+        tmp_file.write_text('integrations: ["a", "b"]')
         expected = {"integrations": ["a", "b"]}
-        self.generic_test_extract_metadata(input, expected)
+        assert update_projects_table.extract_metadata(tmp_file) == expected
 
-        # Combination of basic and integrations fields.
-        input = b'a: 1\nb: 2\nintegrations: ["c", "d"]\ne: 3'
+        tmp_file.write_text('integrations: ["a",  "b"]')
+        expected = {"integrations": ["a", "b"]}
+        assert update_projects_table.extract_metadata(tmp_file) == expected
+
+    def test_combination_of_basic_and_integrations_fields(self, tmp_file):
+        tmp_file.write_text('a: 1\nb: 2\nintegrations: ["c", "d"]\ne: 3')
         expected = {"a": "1", "b": "2", "integrations": ["c", "d"], "e": "3"}
-        self.generic_test_extract_metadata(input, expected)
+        assert update_projects_table.extract_metadata(tmp_file) == expected
+
+
+class TestToTableRow:
+    """Unit tests for the "to_table_row" function."""
 
     def test_to_table_row(self):
         # Metadata without a title - ignore it.
         metadata = {"description": "d", "integrations": ["1"]}
         actual = update_projects_table.to_table_row(Path("dir").absolute(), metadata)
-        self.assertEqual("", actual)
+        assert actual == ""
 
         # Metadata with nothing but the title.
         metadata = {"title": "blah blah blah"}
-        expected = "| [blah blah blah](./dir/) |  |  |\n"
         actual = update_projects_table.to_table_row(Path("dir").absolute(), metadata)
-        self.assertEqual(expected, actual)
+        assert actual == "| [blah blah blah](./dir/) |  |  |\n"
 
         # Regular project with a single integration.
         metadata = {"title": "t", "description": "d", "integrations": ["1"]}
-        expected = "| [t](./dir/) | d | 1 |\n"
         actual = update_projects_table.to_table_row(Path("dir").absolute(), metadata)
-        self.assertEqual(expected, actual)
+        assert actual == "| [t](./dir/) | d | 1 |\n"
 
         # Regular project with multiple integrations.
         metadata = {"title": "t", "description": "d", "integrations": ["1", "2", "3"]}
-        expected = "| [t](./dir/) | d | 1, 2, 3 |\n"
         actual = update_projects_table.to_table_row(Path("dir").absolute(), metadata)
-        self.assertEqual(expected, actual)
+        assert actual == "| [t](./dir/) | d | 1, 2, 3 |\n"
 
-    def generic_test_insert_rows_to_table(self, num_rows, expected):
-        actual = ""
-        with tempfile.NamedTemporaryFile(delete_on_close=False) as f:
-            f.write(b"prefix\n<!--start-table-->\ngarbage\n<!--end-table-->\nsuffix\n")
-            f.close()
-            rows = ["| row |\n"] * num_rows
-            update_projects_table.insert_rows_to_table(Path(f.name), rows)
-            actual = Path(f.name).read_text()
-        self.assertEqual(expected, actual)
 
-    def test_insert_rows_to_table_empty(self):
-        expected = (
+class TestInsertRowsToTable:
+    """Unit tests for the "insert_rows_to_table" function."""
+
+    @pytest.fixture
+    def tmp_file(self, tmp_path):
+        template = "prefix\n<!--start-table-->\ngarbage\n<!--end-table-->\nsuffix\n"
+        fp = tmp_path / "tmp_file"
+        fp.write_text(template)
+        yield fp
+        fp.unlink()
+
+    def test_insert_rows_to_table_empty(self, tmp_file):
+        update_projects_table.insert_rows_to_table(tmp_file, ["| row |\n"] * 0)
+        assert tmp_file.read_text() == (
             "prefix\n<!--start-table-->\n"
             "| Name | Description | Integration |\n"
             "| :--- | :---------- | :---------- |\n"
             "<!--end-table-->\nsuffix\n"
         )
-        self.generic_test_insert_rows_to_table(0, expected)
 
-    def test_insert_rows_to_table_one_row(self):
-        expected = (
+    def test_insert_rows_to_table_one_row(self, tmp_file):
+        update_projects_table.insert_rows_to_table(tmp_file, ["| row |\n"] * 1)
+        assert tmp_file.read_text() == (
             "prefix\n<!--start-table-->\n"
             "| Name | Description | Integration |\n"
             "| :--- | :---------- | :---------- |\n"
             "| row |\n"
             "<!--end-table-->\nsuffix\n"
         )
-        self.generic_test_insert_rows_to_table(1, expected)
 
-    def test_insert_rows_to_table_multiple_rows(self):
-        expected = (
+    def test_insert_rows_to_table_multiple_rows(self, tmp_file):
+        update_projects_table.insert_rows_to_table(tmp_file, ["| row |\n"] * 3)
+        assert tmp_file.read_text() == (
             "prefix\n<!--start-table-->\n"
             "| Name | Description | Integration |\n"
             "| :--- | :---------- | :---------- |\n"
@@ -122,8 +135,3 @@ class TestCreateProjectTable(unittest.TestCase):
             "| row |\n"
             "<!--end-table-->\nsuffix\n"
         )
-        self.generic_test_insert_rows_to_table(3, expected)
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
Decided to use the `pytest-mock` plugin instead of the built-in `monkeypatch` which requires a lot more boilerplate in Purrr's tests.

Refs: INT-171