### PR TITLE
refactor: getenv

### DIFF
--- a/auth0_to_hubspot/program.py
+++ b/auth0_to_hubspot/program.py
@@ -8,7 +8,7 @@ from autokitteh.hubspot import hubspot_client
 from hubspot.crm.contacts import SimplePublicObjectInput
 
 
-LOOKUP_HOURS = int(os.getenv("HOURS") or "24")
+LOOKUP_HOURS = int(os.getenv("HOURS", "24"))
 
 auth0 = auth0_client("auth0_conn")
 hubspot = hubspot_client("hubspot_conn")

--- a/aws_health_to_slack/program.py
+++ b/aws_health_to_slack/program.py
@@ -15,7 +15,7 @@ from autokitteh.google import google_id, google_sheets_client
 from autokitteh.slack import slack_client
 
 
-URL = os.getenv("GOOGLE_SHEET_URL") or ""
+URL = os.getenv("GOOGLE_SHEET_URL", "")
 
 
 def on_schedule(_):
@@ -59,7 +59,7 @@ def _aws_health_events() -> list[dict]:
     """
     try:
         # Remove the unit suffix ("m") and parse as an integer.
-        mins = int((os.getenv("TRIGGER_INTERVAL") or "1m")[:-1])
+        mins = int((os.getenv("TRIGGER_INTERVAL", "1m"))[:-1])
         prev_check = datetime.now(UTC) - timedelta(minutes=mins)
         filter = {"lastUpdatedTimes": [{"from": prev_check}]}
 

--- a/github_copilot_seats/seats.py
+++ b/github_copilot_seats/seats.py
@@ -10,7 +10,7 @@ from autokitteh.slack import slack_client
 from users import github_username_to_slack_user_id
 
 
-GITHUB_ORG_NAME = os.getenv("github_conn__target_name") or ""
+GITHUB_ORG_NAME = os.getenv("github_conn__target_name", "")
 IDLE_HOURS_THRESHOLD = int(os.getenv("IDLE_HOURS_THRESHOLD", "72"))
 MANAGED_LOGINS = os.getenv("MANAGED_LOGINS")
 

--- a/hackernews/program.py
+++ b/hackernews/program.py
@@ -9,7 +9,7 @@ import requests
 
 
 API_URL = "http://hn.algolia.com/api/v1/search_by_date?tags=story&page=0&query="
-POLLING_INTERVAL_SECS = int(os.getenv("POLLING_INTERVAL_SECS") or "120")
+POLLING_INTERVAL_SECS = int(os.getenv("POLLING_INTERVAL_SECS", "120"))
 
 slack = slack_client("slack_connection")
 

--- a/purrr/github_helper.py
+++ b/purrr/github_helper.py
@@ -5,6 +5,6 @@ import os
 from autokitteh.github import github_client
 
 
-ORG_NAME = os.getenv("github_conn__target_name") or ""
+ORG_NAME = os.getenv("github_conn__target_name", "")
 
 shared_client = github_client("github_conn")

--- a/purrr/slack_helper.py
+++ b/purrr/slack_helper.py
@@ -15,7 +15,7 @@ import users
 _CHANNEL_PREFIX = os.getenv("SLACK_CHANNEL_PREFIX", "_pr")
 
 # Visibility of PR channels in Slack: "public" (default) or "private".
-_IS_PRIVATE = os.getenv("SLACK_CHANNEL_VISIBILITY") or ""
+_IS_PRIVATE = os.getenv("SLACK_CHANNEL_VISIBILITY", "")
 
 shared_client = slack_client("slack_conn")
 

--- a/reviewkitteh/program.py
+++ b/reviewkitteh/program.py
@@ -17,9 +17,9 @@ from autokitteh.google import google_sheets_client
 from autokitteh.slack import slack_client
 
 
-CHANNEL_ID = os.getenv("CHANNEL_ID")
-ORG_DOMAIN = os.getenv("ORG_DOMAIN")
-SHEET_ID = os.getenv("SHEET_ID")
+CHANNEL_ID = os.getenv("CHANNEL_ID", "")
+ORG_DOMAIN = os.getenv("ORG_DOMAIN", "")
+SHEET_ID = os.getenv("SHEET_ID", "")
 
 github = github_client("github_conn")
 googlesheets = google_sheets_client("googlesheets_conn").spreadsheets().values()

--- a/slack_discord_sync/program.py
+++ b/slack_discord_sync/program.py
@@ -17,8 +17,8 @@ from autokitteh import slack
 import discord
 
 
-DISCORD_CHANNEL_ID = int(os.getenv("DISCORD_CHANNEL_ID"))
-SLACK_CHANNEL_ID = os.getenv("SLACK_CHANNEL_ID")
+DISCORD_CHANNEL_ID = int(os.getenv("DISCORD_CHANNEL_ID", ""))
+SLACK_CHANNEL_ID = os.getenv("SLACK_CHANNEL_ID", "")
 
 # Discord intents that enable the bot to read message content
 intents = discord.Intents.default()

--- a/slack_support/directory.py
+++ b/slack_support/directory.py
@@ -4,7 +4,7 @@ import os
 from autokitteh.google import google_sheets_client
 
 
-DIRECTORY_GOOGLE_SHEET_ID = os.getenv("DIRECTORY_GOOGLE_SHEET_ID")
+DIRECTORY_GOOGLE_SHEET_ID = os.getenv("DIRECTORY_GOOGLE_SHEET_ID", "")
 
 gsheets = google_sheets_client("mygsheets")
 


### PR DESCRIPTION
Change this:
```
os.getenv("key") or "value"
```
To this:
```
os.getenv("key", "value")
```
The result is the same, but the former is a style mistake given the existence of the latter.