### PR TITLE
refactor: self-describing project var

### DIFF
--- a/confluence_to_slack/README.md
+++ b/confluence_to_slack/README.md
@@ -23,12 +23,15 @@ This workflow automates notifications to a Slack channel whenever a new Confluen
 
 ### Cloud Usage (Recommended)
 
-1. Initialize your connections through the UI
+1. Initialize your connections
 2. Navigate to the "TRIGGERS" tab and under the "Actions" column click "Edit"
-3. Update the "CONFLUENCE_SPACE_KEY" variable with the space key of the Confluence space you want to monitor
-4. (Optional) Update the "FILTER_LABEL" variable with the label of the Confluence page you want to monitor
-5. Update the "SLACK_CHANNEL" variable with the name of the Slack channel you want to send messages to
-6. Deploy the project
+3. Update the "CONFLUENCE_SPACE_KEY" placeholder in the filter string, with the ID of the Confluence space you want to monitor
+4. Set/modify these project variables:
+
+   - `FILTER_LABEL` (optional): a specific Confluence page label you limit this project to
+   - `SLACK_CHANNEL_NAME_OR_ID`: the Slack channel you want to send messages to
+
+5. Deploy the project
 
 > [!IMPORTANT]
 > Ensure all connections (Atlassian Confluence, Slack) are properly initialized before the workflow starts running.

--- a/confluence_to_slack/autokitteh.yaml
+++ b/confluence_to_slack/autokitteh.yaml
@@ -1,14 +1,5 @@
 # This YAML file is a declarative manifest that describes the setup of
 # an AutoKitteh project that announces new Confluence pages in Slack.
-#
-# Before deploying this AutoKitteh project:
-# - Set the "CONFLUENCE_SPACE_KEY" in the trigger's filter expression
-# - Set "FILTER_LABEL" for event filtering during runtime
-#   ("" = disable this runtime check)
-# - Set "SLACK_CHANNEL" to the Slack channel name/ID you want to post to
-#
-# After creating this AutoKitteh project by applying this file,
-# initialize its Confluence and Slack connections.
 
 version: v1
 
@@ -17,10 +8,10 @@ project:
   vars:
     - name: FILTER_LABEL
       value: ""
-    - name: SLACK_CHANNEL
+    - name: SLACK_CHANNEL_NAME_OR_ID
       value: ""
     - name: SNIPPET_LENGTH
-      value: "150"
+      value: 150
   connections:
     - name: confluence_connection
       integration: confluence

--- a/confluence_to_slack/program.py
+++ b/confluence_to_slack/program.py
@@ -43,4 +43,5 @@ def _send_slack_message(page, html_body):
     """
 
     slack = slack_client("slack_connection")
-    slack.chat_postMessage(channel=os.getenv("SLACK_CHANNEL"), text=message)
+    channel = os.getenv("SLACK_CHANNEL_NAME_OR_ID", "")
+    slack.chat_postMessage(channel=channel, text=message)

--- a/hackernews/program.py
+++ b/hackernews/program.py
@@ -18,7 +18,7 @@ def on_slack_command(event):
     """Workflow's entry-point.
 
     Extracts a topic from a Slack command, monitors for new articles,
-    and posts updates to `SLACK_CHANNEL`.
+    and posts updates to the same Slack channel.
     """
     topic = event.data.text.split(" ", 1)[-1].strip()
     slack.chat_postMessage(

--- a/slack_discord_sync/autokitteh.yaml
+++ b/slack_discord_sync/autokitteh.yaml
@@ -8,9 +8,9 @@ project:
   name: slack_discord_sync
   vars:
     - name: DISCORD_CHANNEL_ID
-      value: 
-    - name: SLACK_CHANNEL_ID
-      value: 
+      value: ""
+    - name: SLACK_CHANNEL_NAME_OR_ID
+      value: ""
   connections:
     - name: discord_conn
       integration: discord

--- a/slack_discord_sync/program.py
+++ b/slack_discord_sync/program.py
@@ -18,7 +18,7 @@ import discord
 
 
 DISCORD_CHANNEL_ID = int(os.getenv("DISCORD_CHANNEL_ID", ""))
-SLACK_CHANNEL_ID = os.getenv("SLACK_CHANNEL_ID", "")
+SLACK_CHANNEL = os.getenv("SLACK_CHANNEL_NAME_OR_ID", "")
 
 # Discord intents that enable the bot to read message content
 intents = discord.Intents.default()
@@ -32,7 +32,7 @@ slack_message = None
 
 
 def on_discord_message(event):
-    slack_api.chat_postMessage(channel=SLACK_CHANNEL_ID, text=event.data["content"])
+    slack_api.chat_postMessage(channel=SLACK_CHANNEL, text=event.data["content"])
 
 
 def on_slack_message(event):


### PR DESCRIPTION
Project vars: instead of `SLACK_CHANNEL`, use `SLACK_CHANNEL_NAME_OR_ID`. This will help cloud users, in the absence of documentation for project vars.

This is correct because all usages are in https://api.slack.com/methods/chat.postMessage, which accepts names too (which are easier to determine/set-up compared to IDs).

Detection: https://github.com/search?q=repo%3Aautokitteh%2Fkittehub%20SLACK_CHANNEL&type=code