### PR TITLE
chore: standardize manifests

### DIFF
--- a/auth0_to_hubspot/autokitteh.yaml
+++ b/auth0_to_hubspot/autokitteh.yaml
@@ -1,20 +1,22 @@
-# This YAML file is a declarative manifest that describes the setup
-# of an AutoKitteh project that adds new Auth0 users to HubSpot as contacts.
+# This YAML file is a declarative manifest that describes the setup of
+# an AutoKitteh project that adds new Auth0 users to HubSpot as contacts.
 
 version: v1
 
 project:
   name: auth0_to_hubspot
+
   vars:
     - name: HOURS
       value: 24
+
   connections:
     - name: auth0_conn
       integration: auth0
     - name: hubspot_conn
       integration: hubspot
+
   triggers:
     - name: daily
       schedule: "@every 24h"
       call: program.py:check_for_new_users
-

--- a/break_glass/autokitteh.yaml
+++ b/break_glass/autokitteh.yaml
@@ -6,14 +6,17 @@ version: v1
 
 project:
   name: break_glass
+
   vars:
     - name: APPROVAL_CHANNEL
-      value: ""
+      value:
+
   connections:
     - name: jira_connection
       integration: jira
     - name: slack_connection
       integration: slack
+
   triggers:
     - name: slack_slash_command
       connection: slack_connection

--- a/confluence_to_slack/autokitteh.yaml
+++ b/confluence_to_slack/autokitteh.yaml
@@ -5,18 +5,21 @@ version: v1
 
 project:
   name: confluence_to_slack
+
   vars:
     - name: FILTER_LABEL
-      value: ""
+      value:
     - name: SLACK_CHANNEL_NAME_OR_ID
-      value: ""
+      value:
     - name: SNIPPET_LENGTH
       value: 150
+
   connections:
     - name: confluence_connection
       integration: confluence
     - name: slack_connection
       integration: slack
+
   triggers:
     - name: confluence_page_created
       connection: confluence_connection

--- a/data_pipeline/autokitteh.yaml
+++ b/data_pipeline/autokitteh.yaml
@@ -6,9 +6,11 @@ version: v1
 
 project:
   name: pipeline
+
   connections:
     - name: aws_conn
       integration: aws
+
   triggers:
     - name: new_s3_object
       type: webhook

--- a/devops/github_issue_alert/autokitteh.yaml
+++ b/devops/github_issue_alert/autokitteh.yaml
@@ -1,5 +1,5 @@
-# This YAML file is a declarative manifest that describes the setup of
-# an AutoKitteh project that monitors comments on GitHub issues.
+# This YAML file is a declarative manifest that describes the setup
+# of an AutoKitteh project that monitors comments on GitHub issues.
 
 version: v1
 

--- a/devops/reviewkitteh/autokitteh.yaml
+++ b/devops/reviewkitteh/autokitteh.yaml
@@ -8,11 +8,11 @@ project:
 
   vars:
     - name: SLACK_CHANNEL_ID
-      value: ""
+      value:
     - name: GOOGLE_SHEET_ID
-      value: ""
+      value:
     - name: ORG_DOMAIN
-      value: ""
+      value:
 
   connections:
     - name: github_conn

--- a/discord_to_spreadsheet/autokitteh.yaml
+++ b/discord_to_spreadsheet/autokitteh.yaml
@@ -1,31 +1,24 @@
-# This YAML file defines a declarative manifest for an AutoKitteh project that 
-# logs messages from Discord to a Google Sheets document.
-#
-# Before deploying this AutoKitteh project:
-# - Set the "RANGE_NAME" and "SPREADSHEET_ID" in the vars section.
-#   - **SPREADSHEET_ID**: You can find this ID in the URL of your Google Sheet.
-#     It is the part between `/d/` and `/edit` in the URL.
-#     For example, in `https://docs.google.com/spreadsheets/d/your_spreadsheet_id/edit#gid=0`,
-#     `your_spreadsheet_id` is the `SPREADSHEET_ID`.
-# 
-# After applying this file, initialize this AutoKitteh project's
-# Discord and Google Sheets connections.
-
+# This YAML file is a declarative manifest that describes the setup
+# of an AutoKitteh project that logs messages from Discord to a
+# Google Sheets document.
 
 version: v1
 
 project:
   name: discord_to_spreadsheet
+
   vars:
     - name: RANGE_NAME
-      value: 'Sheet1!A1'
+      value: Sheet1!A1
     - name: SPREADSHEET_ID
       value:
+
   connections:
     - name: discord_conn
       integration: discord
     - name: googlesheets_conn
       integration: googlesheets
+
   triggers:
     - name: on_discord_message
       connection: discord_conn

--- a/github_copilot_seats/autokitteh.yaml
+++ b/github_copilot_seats/autokitteh.yaml
@@ -1,24 +1,27 @@
-# This YAML file is a declarative manifest that describes the setup of
-# an AutoKitteh project that manages GitHub Copilot subscriptions.
+# This YAML file is a declarative manifest that describes the setup
+# of an AutoKitteh project that manages GitHub Copilot subscriptions.
 
 version: v1
 
 project:
   name: github_copilot_seats
+
   vars:
     - name: IDLE_HOURS_THRESHOLD
       value: 72
     # Optional: manage GitHub Copilot subscriptions only for these users, separated by commas.
     - name: MANAGED_LOGINS
-      value: ""
+      value:
     # Optional: Slack channel name or ID, for debugging.
     - name: SLACK_LOG_CHANNEL
-      value: ""
+      value:
+
   connections:
     - name: github_conn
       integration: github
     - name: slack_conn
       integration: slack
+
   triggers:
     - name: check_daily
       schedule: "@daily"

--- a/github_marketplace_to_slack/autokitteh.yaml
+++ b/github_marketplace_to_slack/autokitteh.yaml
@@ -10,7 +10,7 @@ project:
   vars:
     - name: GITHUB_WEBHOOK_SECRET
       secret: true
-      value: s3cr3t-p@ssw0rd
+      value:
     - name: SLACK_CHANNEL_NAME_OR_ID
       value: github-marketplace
 

--- a/google_cal_to_asana/autokitteh.yaml
+++ b/google_cal_to_asana/autokitteh.yaml
@@ -5,14 +5,17 @@ version: v1
 
 project:
   name: google_cal_to_asana
+
   vars:
     - name: ASANA_PROJECT_GID
       value:
+
   connections:
     - name: asana_conn
       integration: asana
     - name: google_conn
       integration: googlecalendar
+
   triggers:
     - name: gcal_event_created
       connection: google_conn

--- a/google_forms_to_jira/autokitteh.yaml
+++ b/google_forms_to_jira/autokitteh.yaml
@@ -7,12 +7,14 @@ project:
   name: google_forms_to_jira
   vars:
     - name: JIRA_PROJECT_KEY
-      value: 
+      value:
+
   connections:
     - name: forms_conn
       integration: googleforms
     - name: jira_conn
       integration: jira
+
   triggers:
     - name: google_forms_response
       connection: forms_conn

--- a/hackernews/autokitteh.yaml
+++ b/hackernews/autokitteh.yaml
@@ -1,16 +1,19 @@
-# This YAML file is a declarative manifest that describes the setup of an
-# AutoKitteh project that monitors Hacker News for a specific topic.
+# This YAML file is a declarative manifest that describes the setup of
+# an AutoKitteh project that monitors Hacker News for a specific topic.
 
 version: v1
 
 project:
   name: hackernews_alert
+
   vars:
     - name: POLLING_INTERVAL_SECS
       value: 120
+
   connections:
     - name: slack_connection
       integration: slack
+
   triggers:
     - name: slack_slash_command
       connection: slack_connection

--- a/jenkins_release/autokitteh.yaml
+++ b/jenkins_release/autokitteh.yaml
@@ -8,14 +8,14 @@ project:
 
   vars:
     - name: JENKINS_URL
-      value: "<JENKINS_URL>"
+      value:
     - name: JENKINS_USER
-      value: "<USERNAME>"
+      value:
     - name: JENKINS_PASSWORD
-      value: ""
       secret: true
+      value:
     - name: JOB_NAME
-      value: "<JOB_NAME>"
+      value:
 
   connections:
     - name: github_conn

--- a/jira_google_calendar/assignee_from_schedule/autokitteh.yaml
+++ b/jira_google_calendar/assignee_from_schedule/autokitteh.yaml
@@ -1,27 +1,22 @@
 # This YAML file is a declarative manifest that describes the setup of
 # an AutoKitteh project that sets the assignee of new Atlassian Jira
 # issues based on an on-call rotation in a shared Google Calendar.
-#
-# Before deploying this AutoKitteh project:
-# - Set "SHARED_CALENDAR_ID" to the URL of the shared Google Calendar
-#   ("primary" is the default calendar of the authenticated user)
-# - Set "JIRA_PROJECT_KEY" in the trigger's filter expression
-#
-# After creating this AutoKitteh project by applying this file,
-# initialize its Jira connection.
 
 version: v1
 
 project:
   name: jira_assignee_from_google_calendar_schedule
+
   vars:
     - name: SHARED_CALENDAR_ID
-      value: primary 
+      value: primary
+
   connections:
     - name: google_calendar_connection
       integration: googlecalendar
     - name: jira_connection
       integration: jira
+
   triggers:
     - name: jira_issue_created
       connection: jira_connection

--- a/jira_google_calendar/deadline_to_event/autokitteh.yaml
+++ b/jira_google_calendar/deadline_to_event/autokitteh.yaml
@@ -1,22 +1,18 @@
 # This YAML file is a declarative manifest that describes the setup
 # of an AutoKitteh project that creates events in Google Calendar
 # when Atlassian Jira issues are created in a specific project.
-#
-# Before deploying this AutoKitteh project, set "JIRA_PROJECT_KEY"
-# in the trigger's filter expression.
-#
-# After creating this AutoKitteh project by applying this file,
-# initialize its Jira connection.
 
 version: v1
 
 project:
   name: jira_deadline_to_google_calendar_event
+
   connections:
     - name: jira_connection
       integration: jira
     - name: google_calendar_connection
       integration: googlecalendar
+
   triggers:
     - name: jira_issue_created
       connection: jira_connection

--- a/quickstart/autokitteh.yaml
+++ b/quickstart/autokitteh.yaml
@@ -5,6 +5,7 @@ version: v1
 
 project:
   name: quickstart
+
   triggers:
     - name: http_request
       type: webhook

--- a/reliability/missing_jira_events_monitor/autokitteh.yaml
+++ b/reliability/missing_jira_events_monitor/autokitteh.yaml
@@ -15,9 +15,9 @@ project:
     # Must be identical/equivalent to the "event_type"
     # and/or "filter" fields of the trigger below!
     - name: EVENT_FILTER
-      value: ""
+      value:
     - name: EVENT_DESCRIPTION
-      value: ""
+      value:
     - name: TIMEOUT_HOURS
       value: 24
     - name: PING_HOURS
@@ -36,5 +36,5 @@ project:
       connection: monitored_service_conn
       # Set this CEL expression to match the events you want to monitor.
       # Also set the "EVENT_FILTER" project variable above accordingly!
-      filter: event_type == 'TODO' && data.TODO['TODO'] == 'TODO'
+      filter: event_type == "TODO" && data.TODO["TODO"] == "TODO"
       call: program.py:on_monitor_trigger

--- a/reliability/session_errors_monitor/autokitteh.yaml
+++ b/reliability/session_errors_monitor/autokitteh.yaml
@@ -13,7 +13,7 @@ project:
       value: https://app.autokitteh.cloud
     - name: AUTOKITTEH_AUTH_TOKEN
       secret: true
-      value: ""
+      value:
     - name: SLACK_CHANNEL_NAME_OR_ID
       value: autokitteh-alerts
     - name: TRIGGER_INTERVAL

--- a/room_reservation/autokitteh.yaml
+++ b/room_reservation/autokitteh.yaml
@@ -6,9 +6,11 @@ version: v1
 
 project:
   name: room_reservation
+
   vars:
     - name: GOOGLE_SHEET_ID
       value:
+
   connections:
     - name: calendar_conn
       integration: googlecalendar
@@ -16,6 +18,7 @@ project:
       integration: googlesheets
     - name: slack_conn
       integration: slack
+
   triggers:
     - name: slack_slash_command_available_rooms
       connection: slack_conn

--- a/samples/asana/autokitteh.yaml
+++ b/samples/asana/autokitteh.yaml
@@ -5,13 +5,16 @@ version: v1
 
 project:
   name: asana_sample
+
   vars:
     - name: WORKSPACE_GID
-      value: ""
+      value:
+
   connections:
     - name: asana_conn
       integration: asana
-  triggers:  
+
+  triggers:
     - name: create_task_webhook
       type: webhook
       event_type: get

--- a/samples/atlassian/README.md
+++ b/samples/atlassian/README.md
@@ -5,19 +5,3 @@ demonstrate 2-way integration with Atlassian services and APIs.
 
 - Confluence
 - [Jira](./jira/)
-
-## Connection Notes
-
-AutoKitteh supports three connection modes:
-
-- User impersonation with:
-
-  - [API token](https://id.atlassian.com/manage-profile/security/api-tokens)
-    (available only in Atlassian Cloud)
-
-  - [Personal Access Token (PAT)](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html)
-    (available only in on-prem servers)
-
-- [OAuth 2.0 (3LO) app](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/)
-
-  - [AutoKitteh guide: configuring Atlassian integrations](https://docs.autokitteh.com/integrations/atlassian/config)

--- a/samples/atlassian/jira/autokitteh.yaml
+++ b/samples/atlassian/jira/autokitteh.yaml
@@ -6,9 +6,11 @@ version: v1
 
 project:
   name: jira_sample
+
   connections:
     - name: jira_conn
       integration: jira
+
   triggers:
     - name: jira_comment_created
       connection: jira_conn

--- a/samples/auth0/autokitteh.yaml
+++ b/samples/auth0/autokitteh.yaml
@@ -8,7 +8,7 @@ project:
 
   vars:
     - name: ROLE_ID
-      value: ""
+      value:
     - name: TIME_INTERVAL
       value: 7d
 

--- a/samples/discord/discord_client/autokitteh.yaml
+++ b/samples/discord/discord_client/autokitteh.yaml
@@ -6,9 +6,11 @@ version: v1
 
 project:
   name: discord_client_sample
+
   vars:
     - name: CHANNEL_ID
-      value: 
+      value:
+
   connections:
     - name: discord_conn
       integration: discord

--- a/samples/discord/events/autokitteh.yaml
+++ b/samples/discord/events/autokitteh.yaml
@@ -6,9 +6,11 @@ version: v1
 
 project:
   name: discord_events_sample
+
   connections:
     - name: discord_conn
       integration: discord
+
   triggers:
     - name: discord_message_create
       connection: discord_conn

--- a/samples/google/README.md
+++ b/samples/google/README.md
@@ -6,27 +6,12 @@ demonstrate 2-way integration with Google services and APIs.
 ## Google Workspace
 
 - [Calendar](./calendar/)
-- Drive
+- [Drive](./drive/)
 - [Forms](./forms/)
+- [Gemini](./gemini/)
 - [Gmail](./gmail/)
 - [Sheets](./sheets/)
 
 ## Google Cloud
 
 Coming soon, stay tuned!
-
-## Connection Modes
-
-AutoKitteh supports two connection modes:
-
-- User impersonation (OAuth 2.0)
-
-  - [AutoKitteh guide: configuring Google integrations](https://docs.autokitteh.com/integrations/google/config)
-  - [Learn about authentication and authorization](https://developers.google.com/workspace/guides/auth-overview)
-
-- GCP service account (JSON key)
-
-  - [GCP service accounts overview](https://cloud.google.com/iam/docs/service-account-overview)
-  - [Service account credentials](https://cloud.google.com/iam/docs/service-account-creds)
-  - [Create and delete service account keys](https://cloud.google.com/iam/docs/keys-create-delete)
-  - [Best practices for managing service account keys](https://cloud.google.com/iam/docs/best-practices-for-managing-service-account-keys)

--- a/samples/google/calendar/autokitteh.yaml
+++ b/samples/google/calendar/autokitteh.yaml
@@ -6,9 +6,11 @@ version: v1
 
 project:
   name: google_calendar_sample
+
   connections:
     - name: calendar_conn
       integration: googlecalendar
+
   triggers:
     - name: list_events
       type: webhook

--- a/samples/google/drive/autokitteh.yaml
+++ b/samples/google/drive/autokitteh.yaml
@@ -6,12 +6,15 @@ version: v1
 
 project:
   name: google_drive_sample
+
   connections:
     - name: google_drive_conn
       integration: googledrive
+
   vars:
     - name: USER_EMAIL
       value:
+
   triggers:
     - name: create_new_document
       type: webhook

--- a/samples/google/forms/autokitteh.yaml
+++ b/samples/google/forms/autokitteh.yaml
@@ -9,6 +9,7 @@ project:
   connections:
     - name: forms_conn
       integration: googleforms
+
   triggers:
     - name: add_question
       type: webhook

--- a/samples/google/gemini/autokitteh.yaml
+++ b/samples/google/gemini/autokitteh.yaml
@@ -5,9 +5,11 @@ version: v1
 
 project:
   name: gemini_sample
+
   connections:
     - name: gemini_conn
       integration: googlegemini
+
   triggers:
     - name: trivial_interaction
       type: webhook

--- a/samples/google/gmail/autokitteh.yaml
+++ b/samples/google/gmail/autokitteh.yaml
@@ -6,9 +6,11 @@ version: v1
 
 project:
   name: gmail_sample
+
   connections:
     - name: gmail_conn
       integration: gmail
+
   triggers:
     - name: on_http_get
       type: webhook

--- a/samples/google/sheets/autokitteh.yaml
+++ b/samples/google/sheets/autokitteh.yaml
@@ -6,12 +6,13 @@ version: v1
 
 project:
   name: google_sheets_sample
+
   connections:
     - name: sheets_conn
       integration: googlesheets
+
   triggers:
     - name: http_get
       type: webhook
       event_type: get
       call: program.py:on_http_get
-

--- a/samples/http/autokitteh.yaml
+++ b/samples/http/autokitteh.yaml
@@ -8,6 +8,7 @@ project:
   vars:
     - name: HTTPBIN_BASE_URL
       value: https://httpbin.org/
+
   triggers:
     - name: receive_http_get_or_head
       type: webhook

--- a/samples/openai_chatgpt/autokitteh.yaml
+++ b/samples/openai_chatgpt/autokitteh.yaml
@@ -6,9 +6,11 @@ version: v1
 
 project:
   name: chatgpt_sample
+
   connections:
     - name: chatgpt_conn
       integration: chatgpt
+
   triggers:
     - name: on_http_get
       type: webhook

--- a/samples/runtime_events/autokitteh.yaml
+++ b/samples/runtime_events/autokitteh.yaml
@@ -5,9 +5,10 @@ version: v1
 
 project:
   name: runtime_events_sample
+
   triggers:
     - name: meow_webhook
       type: webhook
       event_type: get
-      filter: data.url.path.endsWith('/meow')
+      filter: data.url.path.endsWith("/meow")
       call: program.py:on_http_get_meow

--- a/samples/scheduler/autokitteh.yaml
+++ b/samples/scheduler/autokitteh.yaml
@@ -6,6 +6,7 @@ version: v1
 
 project:
   name: scheduler_sample
+
   vars:
     - name: GITHUB_OWNER
       value:
@@ -15,10 +16,12 @@ project:
       value: 4 # days
     - name: UPDATE_CUTOFF
       value: 1 # days
+
   connections:
     - name: github_conn
       integration: github
+
   triggers:
     - name: daily
-      schedule: "@daily" # Same as `@midnight', `0 0 * * *', or `@every 1d'.
+      schedule: "@daily" # Same as `@midnight', `@every 1d', or `0 0 * * *'.
       call: program.py:on_cron_trigger

--- a/samples/scheduler/autokitteh.yaml
+++ b/samples/scheduler/autokitteh.yaml
@@ -23,5 +23,5 @@ project:
 
   triggers:
     - name: daily
-      schedule: "@daily" # Same as `@midnight', `@every 1d', or `0 0 * * *'.
+      schedule: "@daily" # Same as "@midnight", "@every 1d", or "0 0 * * *".
       call: program.py:on_cron_trigger

--- a/samples/slack/autokitteh.yaml
+++ b/samples/slack/autokitteh.yaml
@@ -6,9 +6,11 @@ version: v1
 
 project:
   name: slack_sample
+
   connections:
     - name: slack_conn
       integration: slack
+
   triggers:
     - name: slack_app_mention
       connection: slack_conn

--- a/samples/twilio/autokitteh.yaml
+++ b/samples/twilio/autokitteh.yaml
@@ -6,12 +6,15 @@ version: v1
 
 project:
   name: twilio_sample
+
   vars:
     - name: FROM_PHONE_NUMBER
       value:
+
   connections:
     - name: twilio_conn
       integration: twilio
+
   triggers:
     - name: http_get
       type: webhook

--- a/slack_discord_sync/autokitteh.yaml
+++ b/slack_discord_sync/autokitteh.yaml
@@ -1,21 +1,24 @@
 # This YAML file is a declarative manifest that describes the setup
-# of an AutoKitteh project that mirrors messages between Slack and 
+# of an AutoKitteh project that mirrors messages between Slack and
 # Discord using AutoKitteh integrations.
- 
+
 version: v1
 
 project:
   name: slack_discord_sync
+
   vars:
     - name: DISCORD_CHANNEL_ID
-      value: ""
+      value:
     - name: SLACK_CHANNEL_NAME_OR_ID
-      value: ""
+      value:
+
   connections:
     - name: discord_conn
       integration: discord
     - name: slack_conn
       integration: slack
+
   triggers:
     - name: on_discord_message
       connection: discord_conn

--- a/task_chain/event_driven/autokitteh.yaml
+++ b/task_chain/event_driven/autokitteh.yaml
@@ -1,17 +1,16 @@
 # This YAML file is a declarative manifest that describes the setup
 # of an AutoKitteh project that runs a sequence of tasks, using an
 # event-driven approach.
-#
-# After applying this file, initialize this AutoKitteh project's
-# Slack connection.
 
 version: v1
 
 project:
   name: task_chain
+
   connections:
     - name: slack_conn
       integration: slack
+
   triggers:
     - name: slack_slash_command
       connection: slack_conn

--- a/task_chain/single_workflow/advanced/autokitteh.yaml
+++ b/task_chain/single_workflow/advanced/autokitteh.yaml
@@ -1,17 +1,16 @@
 # This YAML file is a declarative manifest that describes the setup
 # of an AutoKitteh project that runs a sequence of tasks, using an
 # advanced single-workflow approach.
-#
-# After applying this file, initialize this AutoKitteh project's
-# Slack connection.
 
 version: v1
 
 project:
   name: task_chain
+
   connections:
     - name: slack_conn
       integration: slack
+
   triggers:
     - name: slack_slash_command
       connection: slack_conn

--- a/task_chain/single_workflow/basic/autokitteh.yaml
+++ b/task_chain/single_workflow/basic/autokitteh.yaml
@@ -1,17 +1,16 @@
 # This YAML file is a declarative manifest that describes the setup
 # of an AutoKitteh project that runs a sequence of tasks, using a
 # basic single-workflow approach.
-#
-# After applying this file, initialize this AutoKitteh project's
-# Slack connection.
 
 version: v1
 
 project:
   name: task_chain
+
   connections:
     - name: slack_conn
       integration: slack
+
   triggers:
     - name: slack_slash_command
       connection: slack_conn

--- a/webhook_to_jira/autokitteh.yaml
+++ b/webhook_to_jira/autokitteh.yaml
@@ -5,9 +5,11 @@ version: v1
 
 project:
   name: webhook_to_jira
+
   connections:
     - name: jira_conn
       integration: jira
+
   triggers:
     - name: http_get_or_post_request
       type: webhook


### PR DESCRIPTION
- Var values: use (null) instead of `""` or invalid placeholders
- Readability: add empty lines between sections
- Use `"` instead of `'`
- Remove obsolete instructions below the file description - documented in the `README.md` files
- Atlassian and Google samples: remove connection instructions - documented in Docusaurus

Refs: INT-240