### PR TITLE
feat: add "send email" walkthrough

### DIFF
--- a/walkthroughs/send_email/autokitteh.yaml
+++ b/walkthroughs/send_email/autokitteh.yaml
@@ -1,0 +1,7 @@
+# This YAML file is a declarative manifest that describes
+# the minimal setup of an AutoKitteh project.
+
+version: v1
+
+project:
+  name: send_email

--- a/walkthroughs/send_email/autokitteh.yaml
+++ b/walkthroughs/send_email/autokitteh.yaml
@@ -5,3 +5,7 @@ version: v1
 
 project:
   name: send_email
+
+  connections:
+    - name: gmail_conn
+      integration: gmail

--- a/walkthroughs/send_email/program.py
+++ b/walkthroughs/send_email/program.py
@@ -6,14 +6,18 @@ from autokitteh.google import gmail_client
 from googleapiclient.errors import HttpError
 
 
-def on_manual_run(event):
-    gmail = gmail_client("<INSERT_CONNECTION_NAME>").users()
+gmail = gmail_client("<INSERT_CONNECTION_NAME>").users()
 
-    msg = f"""From: {event.data.sender}
-    To: {event.data.recipient}
-    Subject: Meow! {event.data.subject}
 
-    {event.data.body}"""
+def on_manual_run(_):
+    profile = gmail.getProfile(userId="me").execute()
+
+    msg = f"""From: {profile["emailAddress"]}
+    To: {profile["emailAddress"]}
+    Subject: Test from AutoKitteh
+
+    Meow! Just wanted to let you know that your cat overlords are pleased with your
+    service today. Keep up the good work with the treats and belly rubs!"""
 
     msg = msg.replace("\n", "\r\n").replace("    ", "")
     msg = base64.urlsafe_b64encode(msg.encode()).decode()

--- a/walkthroughs/send_email/program.py
+++ b/walkthroughs/send_email/program.py
@@ -6,7 +6,7 @@ from autokitteh.google import gmail_client
 from googleapiclient.errors import HttpError
 
 
-gmail = gmail_client("<INSERT_CONNECTION_NAME>").users()
+gmail = gmail_client("gmail_conn").users()
 
 
 def on_manual_run(_):

--- a/walkthroughs/send_email/program.py
+++ b/walkthroughs/send_email/program.py
@@ -1,0 +1,26 @@
+"""Simple workflow for sending emails."""
+
+import base64
+
+from autokitteh.google import gmail_client
+from googleapiclient.errors import HttpError
+
+
+def on_manual_run(event):
+    gmail = gmail_client("<INSERT_CONNECTION_NAME>").users()
+
+    msg = f"""From: {event.data.sender}
+    To: {event.data.recipient}
+    Subject: Meow! {event.data.subject}
+
+    {event.data.body}"""
+
+    msg = msg.replace("\n", "\r\n").replace("    ", "")
+    msg = base64.urlsafe_b64encode(msg.encode()).decode()
+    try:
+        gmail.messages().send(userId="me", body={"raw": msg}).execute()
+    except HttpError as e:
+        print(f"Error: `{e.reason}`")
+        return
+
+    print("Message sent successfully!")


### PR DESCRIPTION
This walkthrough expects data; can the parameters be pre-populated?
<img width="517" alt="image" src="https://github.com/user-attachments/assets/4877042a-e404-4de0-8f23-69e098d68648" />

```
{
    "recipient": "[ENTER RECIPIENT EMAIL HERE]",
    "sender": "[ENTER YOUR EMAIL HERE]",
    "subject": "[ENTER SUBJECT HERE]",
    "body": "[ENTER EMAIL BODY HERE]"
}
```

The connection isn't configured. This is intentional so the user will have to create the connection and then use the connection name in the code.

tested: successfully sent and received email