### PR TITLE
fix: change project name

### DIFF
--- a/ai_agents/langgraph_bot/autokitteh.yaml
+++ b/ai_agents/langgraph_bot/autokitteh.yaml
@@ -4,7 +4,7 @@
 version: v1
 
 project:
-  name: Langgraph google Sheets Bot
+  name: Langgraph_Bot
 
   connections:
     - name: slack_conn
@@ -15,7 +15,7 @@ project:
   triggers:
     - name: on_message
       event_type: app_mention
-      connection: slack
+      connection: slack_conn
       call: program.py:on_app_mention
 
   vars:


### PR DESCRIPTION
The project can't open because the name in the manifest file has space.

creating a ticket to create a python test that check the syntax of the name so we don't have this issue again