### PR TITLE
fix: reduce release size

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -15,7 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: build
-        run: zip -r dist .
+        run: |
+          zip -r dist . \
+            -x "carbcat/_raw.zip" \
+            -x ".git/*"
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: release


### PR DESCRIPTION
 Exclude large files from dist.zip - Modified .github/workflows/dist.yml to exclude:
- carbcat/_raw.zip (13MB)
- .git/* directory

This reduces the distribution package size on the release branch.