### PR TITLE
fix: typo in manifest doesnt match the connection name in python

### DIFF
--- a/bi_weekly_release_notes/autokitteh.yaml
+++ b/bi_weekly_release_notes/autokitteh.yaml
@@ -7,7 +7,7 @@ project:
       integration: chatgpt
     - name: jira_conn
       integration: jira
-    - name: conf_conn
+    - name: confluence_conn
       integration: confluence
     - name: gmail_conn
       integration: gmail


### PR DESCRIPTION
typo in the manifest file - it doesnt match the connection name in python.
Before fix:
`autokitteh.yaml` - **conf_conn**
`program.py` - **confluence_conn**

After fix:
`autokitteh.yaml` - **confluence_conn**
`program.py` - **confluence_conn**